### PR TITLE
fix(sindarian-ui): correct ref type in CommandList

### DIFF
--- a/packages/sindarian-ui/src/components/ui/command/index.tsx
+++ b/packages/sindarian-ui/src/components/ui/command/index.tsx
@@ -63,7 +63,7 @@ function CommandList({
   children,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.List>) {
-  const listRef = React.useRef<HTMLUListElement>(null)
+  const listRef = React.useRef<HTMLDivElement>(null)
 
   React.useEffect(() => {
     const listElement = listRef.current


### PR DESCRIPTION
Update listRef to HTMLDivElement to match the actual element type rendered by cmdk's List component.

X-Lerian-Ref: 0x1

# Pull Request Checklist

## Pull Request Type

[//]: # 'Check the appropriate box for the type of pull request.'

- [ ] Sindarian Server
- [x] Sindarian UI

## Checklist

Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes

[//]: # 'Add any additional notes, context, or explanation that could be helpful for reviewers.'

## Obs: Please, always remember to target your PR to develop branch instead of main.
