### PR TITLE
refactor(sindarian-ui): improve dark mode contrast and link visibility

### DIFF
--- a/packages/sindarian-ui/src/components/page-header/index.tsx
+++ b/packages/sindarian-ui/src/components/page-header/index.tsx
@@ -187,7 +187,7 @@ export function PageHeaderCollapsibleInfo({
             <h1 className="text-foreground text-xl font-bold">{question}</h1>
 
             <div className="flex items-start gap-6">
-              <p className="text-shadcn-500 max-w-2xl text-sm font-medium leading-relaxed">
+              <p className="text-shadcn-500 max-w-2xl text-sm leading-relaxed font-medium">
                 {answer}
               </p>
 
@@ -196,7 +196,7 @@ export function PageHeaderCollapsibleInfo({
                   target="_blank"
                   rel="noopener noreferrer"
                   href={href}
-                  className="text-shadcn-600 whitespace-nowrap text-sm font-medium underline underline-offset-4"
+                  className="text-shadcn-600 dark:text-shadcn-400 text-sm font-medium whitespace-nowrap underline underline-offset-4"
                 >
                   {seeMore}
                 </a>

--- a/packages/sindarian-ui/src/globals.css
+++ b/packages/sindarian-ui/src/globals.css
@@ -275,13 +275,13 @@
     /* Shadcn — Core */
     --background: 240 4% 16%; /* base/800 = #27272A */
     --foreground: 240 5% 96%; /* base/100 = #F4F4F5 */
-    --muted: 240 5% 26%; /* base/700 = #3F3F46 */
+    --muted: 240 5% 34%; /* base/600 = #52525B */
     --muted-foreground: 240 5% 65%; /* base/400 = #A1A1AA */
     --card: var(--container-surface);
     --card-foreground: var(--container-text);
     --popover: 240 4% 16%; /* base/800 = #27272A */
     --popover-foreground: 240 5% 96%; /* base/100 = #F4F4F5 */
-    --border: 240 5% 26%; /* base/700 = #3F3F46 */
+    --border: 240 5% 34%; /* base/600 = #52525B */
     --input: 240 4% 16%; /* base/800 = #27272A */
     --primary: 240 5% 96%; /* base/100 = #F4F4F5 */
     --primary-foreground: 240 4% 16%; /* base/800 = #27272A */


### PR DESCRIPTION
Bump --muted and --border dark theme tokens from base/700 to base/600 for better contrast. Add dark:text-shadcn-400 variant to page header links for improved visibility.

X-Lerian-Ref: 0x1

# Pull Request Checklist

## Pull Request Type

[//]: # 'Check the appropriate box for the type of pull request.'

- [ ] Sindarian Server
- [ ] Sindarian UI

## Checklist

Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes

[//]: # 'Add any additional notes, context, or explanation that could be helpful for reviewers.'

## Obs: Please, always remember to target your PR to develop branch instead of main.
