### PR TITLE
fix(sindarian-ui): improve active tab trigger text contrast in light mode

### DIFF
--- a/packages/sindarian-ui/src/components/ui/tabs/styles.css
+++ b/packages/sindarian-ui/src/components/ui/tabs/styles.css
@@ -3,7 +3,7 @@
   --color-tabs-trigger-hover: var(--color-card);
   --color-tabs-trigger-text-hover: var(--color-body-text);
   --color-tabs-trigger-active: var(--color-accent);
-  --color-tabs-trigger-text-active: var(--color-primary-foreground);
+  --color-tabs-trigger-text-active: var(--color-accent-foreground);
 }
 
 @layer components {


### PR DESCRIPTION
Summary

  - Fix poor text contrast on active TabsTrigger in light mode by switching the text color token from primary-foreground (white) to accent-foreground (dark)

  Problem

  The active tab trigger used --color-primary-foreground (white #FFFFFF) as text color over the accent background (yellow #FEED02), resulting in poor readability
   and failing WCAG contrast requirements in light mode.

  Solution

  Changed --color-tabs-trigger-text-active to use --color-accent-foreground, which is the semantic token designed for text on accent-colored backgrounds. This
  provides a dark text color (#0D0D12) that ensures proper contrast on the yellow background in both light and dark modes.

  Test plan

  - Verify active tab text is dark and readable on yellow background in light mode
  - Verify active tab text remains dark and readable in dark mode (no visual regression)
  - Verify inactive and hover tab states are unaffected