### PR TITLE
chore(ci): adopt shared workflows for changelog and notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,35 +260,20 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
 
-  # AI-powered changelog generation (per-package, same as original)
+  # AI-powered changelog generation using shared workflow
   generate-changelog:
-    name: Generate Changelog ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    name: Generate Changelog
     needs: [get-changed-paths, release]
     if: needs.get-changed-paths.outputs.matrix != '[]'
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.get-changed-paths.outputs.matrix) }}
-    steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-
-      - uses: LerianStudio/github-actions-gptchangelog/helm-repo@chart
-        with:
-          WORK_DIR: packages/${{ matrix.name }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LERIAN_CI_CD_USER_GPG_KEY: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-          LERIAN_CI_CD_USER_GPG_KEY_PASSWORD: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-          LERIAN_CI_CD_USER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          LERIAN_CI_CD_USER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.18.1
+    with:
+      runner_type: ubuntu-latest
+      filter_paths: |
+        packages/sindarian-server
+        packages/sindarian-ui
+      path_level: '2'
+      stable_releases_only: false
+    secrets: inherit
 
   # Release notification using shared workflow (Slack only)
   release-notification:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
   npm-audit:
     name: Run npm audit
     needs: get-changed-paths
+    if: needs.get-changed-paths.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
         packages/sindarian-server
         packages/sindarian-ui
       path_level: '2'
-      stable_releases_only: true
+      stable_releases_only: false
     secrets: inherit
 
   # Release notification using shared workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ on:
       - develop
     paths-ignore:
       - '.gitignore'
-      - '**/*.env' # Ignores all .env files
-      - '*.env' # Ignores .env files in the root directory
-      - '**/*.md' # Ignores all .md files
-      - '*.md' # Ignores .md files in the root directory
-      - '**/*.txt' # Ignores all .txt files
-      - '*.txt' # Ignores .txt files in the root directory
+      - '**/*.env'
+      - '*.env'
+      - '**/*.md'
+      - '*.md'
+      - '**/*.txt'
+      - '*.txt'
     tags-ignore: ['**']
   workflow_dispatch:
     inputs:
@@ -41,67 +41,56 @@ jobs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Get changed paths
         id: changed-paths
-        uses: LerianStudio/github-actions-changed-paths@main
+        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1.18.1
         with:
-          filter_paths: packages/
-          get_app_name: true
-          path_level: 2
+          filter-paths: |
+            packages/sindarian-server
+            packages/sindarian-ui
+          path-level: '2'
+          get-app-name: 'true'
 
   npm-audit:
-    name: Run npm audit and fix vulnerabilities
+    name: Run npm audit
     needs: get-changed-paths
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
-
-      - name: Cache Node.js modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run npm audit (non-blocking)
-        run: |
-          echo "🔍 Running npm audit with moderate threshold..."
-          npm audit --omit=dev --audit-level=moderate || echo "🟡 Vulnerabilities found, but audit did not block pipeline"
-
-      - name: Attempt to fix vulnerabilities
-        run: npm audit fix || echo "ℹ️ No fixable vulnerabilities or none needed"
+        run: npm audit --omit=dev --audit-level=moderate || true
 
   # Run tests for changed packages
   test:
-    name: 🧪 Test ${{ matrix.name }}
+    name: Test ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.get-changed-paths.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -113,19 +102,20 @@ jobs:
         run: npm run test -- --filter=@lerianstudio/${{ matrix.name }}
 
   test-e2e:
-    name: 🧪 Test E2E ${{ matrix.name }}
+    name: Test E2E ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.get-changed-paths.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -138,30 +128,30 @@ jobs:
 
   # Release packages sequentially to avoid Git conflicts
   release:
-    name: 🚀 Release ${{ matrix.name }}
+    name: Release ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: [get-changed-paths, npm-audit, test, test-e2e]
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
-      max-parallel: 1  # Force sequential execution
+      max-parallel: 1
       matrix:
         include: ${{ fromJSON(needs.get-changed-paths.outputs.matrix) }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          private_key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -252,13 +242,13 @@ jobs:
         run: npm install --save-dev @semantic-release/exec
 
       - name: Run Semantic Release for ${{ matrix.name }}
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         with:
           ci: false
           semantic_version: 23.0.8
           extra_plugins: |
             conventional-changelog-conventionalcommits@v7.0.2
-            @saithodev/semantic-release-backmerge
+            @saithodev/semantic-release-backmerge@4.0.1
             @semantic-release/git
             @semantic-release/npm
         env:
@@ -270,30 +260,31 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
 
+  # AI-powered changelog generation using shared workflow
   generate-changelog:
-    name: 📝 Generate AI-powered Changelog
-    runs-on: ubuntu-latest
+    name: Generate Changelog
     needs: [get-changed-paths, release]
     if: needs.get-changed-paths.outputs.matrix != '[]'
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.get-changed-paths.outputs.matrix) }}
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.18.1
+    with:
+      runner_type: ubuntu-latest
+      filter_paths: |
+        packages/sindarian-server
+        packages/sindarian-ui
+      path_level: '2'
+      stable_releases_only: true
+    secrets: inherit
 
-      - uses: LerianStudio/github-actions-gptchangelog/helm-repo@chart
-        with:
-          WORK_DIR: packages/${{ matrix.name }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LERIAN_CI_CD_USER_GPG_KEY: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-          LERIAN_CI_CD_USER_GPG_KEY_PASSWORD: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-          LERIAN_CI_CD_USER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          LERIAN_CI_CD_USER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+  # Release notification using shared workflow
+  release-notification:
+    name: Release Notification
+    needs: [release, generate-changelog]
+    if: always() && needs.release.result == 'success'
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@v1.18.1
+    with:
+      product_name: Console SDK
+    secrets:
+      APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,22 +260,37 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
 
-  # AI-powered changelog generation using shared workflow
+  # AI-powered changelog generation (per-package, same as original)
   generate-changelog:
-    name: Generate Changelog
+    name: Generate Changelog ${{ matrix.name }}
+    runs-on: ubuntu-latest
     needs: [get-changed-paths, release]
     if: needs.get-changed-paths.outputs.matrix != '[]'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.18.1
-    with:
-      runner_type: ubuntu-latest
-      filter_paths: |
-        packages/sindarian-server
-        packages/sindarian-ui
-      path_level: '2'
-      stable_releases_only: false
-    secrets: inherit
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.get-changed-paths.outputs.matrix) }}
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
 
-  # Release notification using shared workflow
+      - uses: LerianStudio/github-actions-gptchangelog/helm-repo@chart
+        with:
+          WORK_DIR: packages/${{ matrix.name }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LERIAN_CI_CD_USER_GPG_KEY: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
+          LERIAN_CI_CD_USER_GPG_KEY_PASSWORD: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
+          LERIAN_CI_CD_USER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          LERIAN_CI_CD_USER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+
+  # Release notification using shared workflow (Slack only)
   release-notification:
     name: Release Notification
     needs: [release, generate-changelog]
@@ -286,5 +301,4 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,7 @@ jobs:
         run: npm install --save-dev @semantic-release/exec
 
       - name: Run Semantic Release for ${{ matrix.name }}
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@v4
         with:
           ci: false
           semantic_version: 23.0.8


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type

- [x] Sindarian Server
- [x] Sindarian UI

## Description

Migrates the release workflow to use LerianStudio shared workflows where they fit, while keeping the custom release job for NPM publishing.

### Changes:
- **Changelog**: Replaced `LerianStudio/github-actions-gptchangelog/helm-repo@chart` with shared `gptchangelog.yml@v1.18.1` (uses OpenRouter API via `secrets: inherit`)
- **Notifications**: Added `release-notification.yml@v1.18.1` for Discord/Slack release notifications
- **Changed paths**: Migrated from `github-actions-changed-paths@main` to `shared-workflows/src/config/changed-paths@v1.18.1` (pinned version)
- **Action versions**: Updated checkout@v6, setup-node@v6, create-github-app-token@v2, semantic-release-action@v6
- **npm-audit**: Simplified (use setup-node cache, `npm ci`, removed auto-fix step)
- **Test matrices**: Added `fail-fast: false` for better error visibility

### Note:
The `OPENROUTER_API_KEY` secret must be configured at org/repo level for the shared gptchangelog workflow to work (replaces the previous `OPENAI_API_KEY`).

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [x] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Release job with NPM publishing kept custom since the shared `typescript-release.yml` doesn't support `@semantic-release/npm` with `pkgRoot` for monorepo package publishing.