### PR TITLE
fix(ci): disable changelog generation for beta releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,7 @@ jobs:
         packages/sindarian-server
         packages/sindarian-ui
       path_level: '2'
-      stable_releases_only: false
+      stable_releases_only: true
     secrets: inherit
 
   # Release notification using shared workflow (Slack only)

--- a/packages/sindarian-server/src/index.ts
+++ b/packages/sindarian-server/src/index.ts
@@ -3,6 +3,7 @@
 
 import 'reflect-metadata'
 
+
 export * from './constants'
 export * from './utils/apply-decorators'
 export * from './context'


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type

- [ ] Sindarian Server
- [ ] Sindarian UI

> CI/Infrastructure only — no package code changes.

## Description

Sets `stable_releases_only: true` on the shared `gptchangelog.yml` workflow so AI-powered changelog generation is skipped for beta releases on `develop`.

## Checklist

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

One-line change: `stable_releases_only: false` → `true`.