### PR TITLE
fix(ci): restrict changelog generation to main branch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,6 @@ jobs:
   # AI-powered changelog generation using shared workflow
   generate-changelog:
     name: Generate Changelog
-    continue-on-error: true
     needs: [get-changed-paths, release]
     if: needs.get-changed-paths.outputs.matrix != '[]' && github.ref_name == 'main'
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.18.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
   generate-changelog:
     name: Generate Changelog
     needs: [get-changed-paths, release]
-    if: needs.get-changed-paths.outputs.matrix != '[]'
+    if: needs.get-changed-paths.outputs.matrix != '[]' && github.ref_name == 'main'
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.18.1
     with:
       runner_type: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,7 @@ jobs:
   # AI-powered changelog generation using shared workflow
   generate-changelog:
     name: Generate Changelog
+    continue-on-error: true
     needs: [get-changed-paths, release]
     if: needs.get-changed-paths.outputs.matrix != '[]' && github.ref_name == 'main'
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.18.1

--- a/packages/sindarian-server/src/index.ts
+++ b/packages/sindarian-server/src/index.ts
@@ -3,7 +3,6 @@
 
 import 'reflect-metadata'
 
-
 export * from './constants'
 export * from './utils/apply-decorators'
 export * from './context'


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type

- [ ] Sindarian Server
- [ ] Sindarian UI

> CI/Infrastructure only — no package code changes.

## Description

Adds `github.ref_name == 'main'` guard to the `generate-changelog` job so it only runs on pushes to `main`.

The `stable_releases_only: true` parameter in the shared `gptchangelog.yml` workflow was not enough to prevent changelog generation on `develop` — the tag detection logic doesn't work correctly for non-tag-push triggers. This explicit branch guard ensures changelogs are never generated for beta releases.

## Checklist

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Evidence: workflow run https://github.com/LerianStudio/console-sdk/actions/runs/23544924759 showed changelog running on `develop` despite `stable_releases_only: true`.