### PR TITLE
Adds AI scaffolding commands and project documentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,76 @@
+## Console SDK Monorepo
+
+TypeScript monorepo for Lerian's frontend framework ecosystem. Published under `@lerianstudio` on npm.
+
+### Packages
+
+| Package | Description |
+|---------|-------------|
+| `sindarian-server` | NestJS-inspired framework for Next.js (decorators, DI, middleware) |
+| `sindarian-ui` | 35+ React component library (Radix UI + ShadCN + Tailwind) |
+| `sindarian-logs` | Request-scoped logging with `@Traceable()` decorator |
+| `sindarian-i18n-cli` | i18n extraction, validation, and key diffing CLI |
+| `utils` (internal) | Shared ESLint, Jest, and TypeScript base configs |
+
+### Commands
+
+| Task | Command |
+|------|---------|
+| Build all | `npx turbo build` |
+| Build one | `npx turbo build --filter=@lerianstudio/{pkg}` |
+| Test all | `npx turbo test` |
+| Lint all | `npx turbo lint` |
+| Type check | `npx turbo check-types` |
+
+### Commit Conventions
+
+Conventional commits scoped to package short names:
+- `feat(sindarian-ui): add DatePicker component`
+- `fix(sindarian-server): resolve guard execution order`
+- `chore(sindarian-logs): bump pino to v9.1`
+
+Valid scopes: `sindarian-server`, `sindarian-ui`, `sindarian-logs`, `sindarian-i18n-cli`
+
+### Release Process
+
+- Semantic Release on push to `main` (stable) or `develop` (beta prerelease)
+- Tag format: `@lerianstudio/{package}-v{version}`
+- Each package has its own `.releaserc.cjs` extending `.releaserc.base.cjs`
+- Releases are sequential (max-parallel: 1) to avoid npm conflicts
+
+### Inter-Package Dependencies
+
+```
+sindarian-logs → sindarian-server (peer dependency)
+sindarian-ui   → (standalone)
+sindarian-i18n-cli → (standalone)
+```
+
+When modifying sindarian-server's public API, check sindarian-logs for breakage.
+
+### Shared Configuration
+
+Base configs live in `packages/utils/` (not published):
+- `tsconfig.json` — Extended by all packages
+- `eslint.config.mjs` — Base lint rules
+- `jest.config.ts` — Base test config
+
+### Code Style
+
+- Prettier: 2-space indent, no semicolons, single quotes, Tailwind plugin
+- TypeScript strict mode in all packages
+- Path aliases: `@/*` → `./src/*`
+- All public API exported through barrel files (`src/index.ts`)
+
+### Adding a New Package
+
+Use `/create-library {name}` to scaffold a new package with the correct structure.
+
+## Collaboration Guidelines
+
+- **Challenge and question**: Don't immediately agree or proceed with requests that seem suboptimal, unclear, or potentially problematic
+- **Push back constructively**: If a proposed approach has issues, suggest better alternatives with clear reasoning
+- **Think critically**: Consider edge cases, performance implications, maintainability, and best practices before implementing
+- **Seek clarification**: Ask follow-up questions when requirements are ambiguous or could be interpreted multiple ways
+- **Propose improvements**: Suggest better patterns, more robust solutions, or cleaner implementations when appropriate
+- **Be a thoughtful collaborator**: Act as a good teammate who helps improve the overall quality and direction of the project

--- a/.claude/commands/create-form-field.md
+++ b/.claude/commands/create-form-field.md
@@ -91,7 +91,7 @@ function BaseComponent(args: Omit<{Name}FieldProps, 'name' | 'control'>) {
   const form = useForm()
   return (
     <Form {...form}>
-      <form className="w-[320px] space-y-4">
+      <form className="w-[320px] space-y-4" onSubmit={(e) => e.preventDefault()}>
         <{Name}Field
           {...args}
           control={form.control}

--- a/.claude/commands/create-form-field.md
+++ b/.claude/commands/create-form-field.md
@@ -1,0 +1,157 @@
+---
+description: Create a new form field component in sindarian-ui that wraps a UI primitive with react-hook-form integration. Auto-triggers when user asks to add, create, or scaffold a form field, controlled field, or field wrapper.
+---
+
+You are creating a new form field component in `packages/sindarian-ui` that wraps an existing UI component with react-hook-form. The user provides the field name (e.g., `date-picker-field`, `toggle-field`).
+
+## Naming
+
+- Directory: kebab-case ending in `-field` (e.g., `date-picker-field`)
+- Component export: PascalCase (e.g., `DatePickerField`)
+- Props type: PascalCase + `Props` suffix (e.g., `DatePickerFieldProps`)
+
+## Prerequisites
+
+The underlying UI component MUST already exist in `src/components/ui/`. If it doesn't, create it first using `/create-ui-component`.
+
+## Files to create
+
+### 1. `src/components/form/{name}/index.tsx` — Field implementation
+
+```tsx
+'use client'
+
+import * as React from 'react'
+import { Control, FieldValues, Path } from 'react-hook-form'
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+// Import the underlying UI component:
+// import { {UiComponent} } from '@/components/ui/{ui-component-name}'
+
+export type {Name}FieldProps<T extends FieldValues = FieldValues> = {
+  name: string
+  label?: React.ReactNode
+  control: Control<T>
+  required?: boolean
+  disabled?: boolean
+  readOnly?: boolean
+  placeholder?: string
+  // Add component-specific props here
+}
+
+export const {Name}Field = <T extends FieldValues = FieldValues>({
+  name,
+  label,
+  control,
+  required,
+  disabled,
+  readOnly,
+  placeholder,
+  ...others
+}: {Name}FieldProps<T>) => {
+  return (
+    <FormField
+      name={name as Path<T>}
+      control={control}
+      {...others}
+      render={({ field }) => (
+        <FormItem required={required}>
+          {label && <FormLabel>{label}</FormLabel>}
+          <FormControl>
+            {/* Replace with actual UI component, passing field props */}
+            {/* <{UiComponent} {...field} disabled={disabled} readOnly={readOnly} placeholder={placeholder} /> */}
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+```
+
+**Important patterns:**
+- If the UI component uses a value type different from string (e.g., `Date`, `boolean`), handle conversion in the render function between `field.value` and the component's expected type.
+- For popover-based fields (date picker, combobox), manage `open` state locally and close on selection.
+- Always pass `field.onChange` to sync with react-hook-form.
+
+### 2. `src/components/form/{name}/{name}.stories.tsx` — Story with form wrapper
+
+```tsx
+import { Meta, StoryObj } from '@storybook/nextjs'
+import { useForm } from 'react-hook-form'
+import { Form } from '@/components/ui/form'
+import { {Name}Field, {Name}FieldProps } from '.'
+
+function BaseComponent(args: Omit<{Name}FieldProps, 'name' | 'control'>) {
+  const form = useForm()
+  return (
+    <Form {...form}>
+      <form className="w-[320px] space-y-4">
+        <{Name}Field
+          {...args}
+          control={form.control}
+          name="fieldName"
+        />
+      </form>
+    </Form>
+  )
+}
+
+const meta: Meta<{Name}FieldProps> = {
+  title: 'Components/Form/{Name}Field',
+  argTypes: {},
+}
+
+export default meta
+
+export const Default: StoryObj<{Name}FieldProps> = {
+  args: {
+    label: '{Display Name}',
+    placeholder: 'Select...',
+  },
+  render: (args) => <BaseComponent {...args} />,
+}
+
+export const Required: StoryObj<{Name}FieldProps> = {
+  args: {
+    label: '{Display Name}',
+    required: true,
+  },
+  render: (args) => <BaseComponent {...args} />,
+}
+
+export const Disabled: StoryObj<{Name}FieldProps> = {
+  args: {
+    label: '{Display Name}',
+    disabled: true,
+  },
+  render: (args) => <BaseComponent {...args} />,
+}
+```
+
+## Wiring
+
+Add export to `packages/sindarian-ui/src/components/form/index.ts`:
+
+```typescript
+export * from './{name}'
+```
+
+Place it alphabetically among existing form field exports.
+
+## Verification
+
+1. Run `npx turbo build --filter=@lerianstudio/sindarian-ui` to confirm it compiles
+2. Run `npx turbo check-types --filter=@lerianstudio/sindarian-ui` for type safety
+
+## After creation
+
+Tell the user:
+- Which files were created
+- Remind them to uncomment and wire the actual UI component import
+- If the field handles non-string values, note they need to add value conversion logic

--- a/.claude/commands/create-library.md
+++ b/.claude/commands/create-library.md
@@ -1,0 +1,132 @@
+---
+description: Scaffold a new @lerianstudio library package in the monorepo
+---
+
+You are scaffolding a new library package in the console-sdk monorepo. The user will provide a package name.
+
+## Validation
+
+- Name MUST be kebab-case (e.g., `sindarian-auth`, `sindarian-cache`)
+- Name SHOULD start with `sindarian-` to match existing conventions
+- If the name doesn't start with `sindarian-`, confirm with the user before proceeding
+
+## Steps
+
+### 1. Create directory structure
+
+Create `packages/{name}/` with:
+
+```
+packages/{name}/
+├── src/
+│   └── index.ts
+├── .claude/
+│   └── CLAUDE.md
+├── package.json
+├── tsconfig.json
+├── jest.config.ts
+├── .releaserc.cjs
+└── CHANGELOG.md
+```
+
+### 2. File contents
+
+**src/index.ts** — Empty barrel:
+```typescript
+// Public API exports
+```
+
+**package.json**:
+```json
+{
+  "name": "@lerianstudio/{name}",
+  "version": "1.0.0-beta.0",
+  "description": "",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc && tsc-alias",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint src/",
+    "test": "jest"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LerianStudio/console-sdk.git"
+  },
+  "license": "ISC"
+}
+```
+
+**tsconfig.json**:
+```json
+{
+  "extends": "../utils/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}
+```
+
+**jest.config.ts**:
+```typescript
+import baseConfig from '../utils/jest.config'
+
+export default {
+  ...baseConfig,
+}
+```
+
+**.releaserc.cjs** — Read an existing package's `.releaserc.cjs` (e.g., `packages/sindarian-server/.releaserc.cjs`) and create one with the same structure but updated for the new package name.
+
+**CHANGELOG.md**:
+```markdown
+# Changelog
+```
+
+**.claude/CLAUDE.md** — Template:
+```markdown
+## {Package Display Name}
+
+{Brief description — fill in after implementation}
+
+### Architecture
+
+{Describe the key abstractions and patterns}
+
+### Public API
+
+{List the main exports and their purpose}
+
+### Adding New Features
+
+{Step-by-step recipe for common additions}
+
+### Testing
+
+{Testing conventions and patterns}
+```
+
+### 3. Install dependencies
+
+Run `npm install` from the repo root to update the workspace lockfile.
+
+### 4. Verify
+
+Run `npx turbo build --filter=@lerianstudio/{name}` to confirm the package builds.
+
+### 5. Report
+
+Tell the user:
+- Which files were created
+- Remind them to fill in the CLAUDE.md template
+- Remind them to add the package scope to the commit conventions if it differs from the directory name

--- a/.claude/commands/create-ui-component.md
+++ b/.claude/commands/create-ui-component.md
@@ -1,0 +1,152 @@
+---
+description: Create a new UI component in sindarian-ui with CVA variants, Storybook story, MDX docs, and barrel export wiring. Auto-triggers when user asks to add, create, or scaffold a component in the UI library.
+---
+
+You are creating a new UI primitive component in `packages/sindarian-ui`. The user provides the component name (e.g., `date-picker`, `badge`, `toggle`).
+
+## Naming
+
+- Directory and file slug: kebab-case (e.g., `date-picker`)
+- Component export: PascalCase (e.g., `DatePicker`)
+- Variants const: camelCase + `Variants` suffix (e.g., `datePickerVariants`)
+- Data slot: kebab-case matching directory name
+
+## Files to create
+
+All under `packages/sindarian-ui/src/components/ui/{name}/`:
+
+### 1. `index.tsx` — Component implementation
+
+```tsx
+'use client'
+
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const {name}Variants = cva(
+  '', // base classes
+  {
+    variants: {
+      variant: {
+        default: '',
+      },
+      size: {
+        default: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export type {Name}Props = React.ComponentProps<'div'> &
+  VariantProps<typeof {name}Variants> & {
+    // Add custom props here
+  }
+
+function {Name}({ className, variant, size, ...props }: {Name}Props) {
+  return (
+    <div
+      className={cn({name}Variants({ variant, size }), className)}
+      data-slot="{kebab-name}"
+      {...props}
+    />
+  )
+}
+
+export { {Name}, {name}Variants }
+```
+
+Adapt the base HTML element (`div`, `button`, `input`, etc.) based on what the component represents. If wrapping a Radix UI primitive, import from `@radix-ui/react-*` and forward refs accordingly.
+
+### 2. `{name}.stories.tsx` — Storybook story
+
+```tsx
+import { Meta, StoryObj } from '@storybook/nextjs'
+import { {Name}, {Name}Props } from '.'
+
+const meta: Meta<{Name}Props> = {
+  title: 'Primitives/{Name}',
+  component: {Name},
+  argTypes: {},
+}
+
+export default meta
+
+export const Default: StoryObj<{Name}Props> = {
+  args: {},
+  render: (args) => <{Name} {...args} />,
+}
+```
+
+Add additional stories for each variant and notable state (disabled, with icon, etc.).
+
+### 3. `{name}.mdx` — Storybook documentation
+
+```mdx
+import { Canvas, Meta, Controls, Primary } from '@storybook/addon-docs'
+import * as Story from './{name}.stories'
+
+<Meta of={Story} />
+
+# {Name}
+
+{One-line description of the component.}
+
+<Canvas of={Story.Default} />
+
+<Primary />
+<Controls />
+```
+
+### 4. `styles.css` (optional) — Component-specific Tailwind styles
+
+Only create if the component needs custom CSS beyond inline Tailwind classes:
+
+```css
+@theme inline {
+  /* Component CSS variables */
+}
+
+@layer components {
+  .{name}-base {
+    @apply /* base styles */;
+  }
+}
+```
+
+## Wiring
+
+### If `styles.css` was created:
+
+Add import to `packages/sindarian-ui/src/globals.css` alongside existing component style imports:
+
+```css
+@import './components/ui/{name}/styles.css';
+```
+
+### Barrel export:
+
+Add to `packages/sindarian-ui/src/index.tsx`:
+
+```typescript
+export * from './components/ui/{name}'
+```
+
+Place it alphabetically among the existing UI component exports.
+
+## Verification
+
+1. Run `npx turbo build --filter=@lerianstudio/sindarian-ui` to confirm it compiles
+2. Run `npx turbo check-types --filter=@lerianstudio/sindarian-ui` for type safety
+3. If Storybook is running, verify the story renders at the expected path
+
+## After creation
+
+Tell the user:
+- Which files were created and where
+- Remind them to customize the CVA variants for their use case
+- If it wraps a Radix primitive, suggest which `@radix-ui/react-*` package to install

--- a/.claude/commands/create-ui-component.md
+++ b/.claude/commands/create-ui-component.md
@@ -8,7 +8,7 @@ You are creating a new UI primitive component in `packages/sindarian-ui`. The us
 
 - Directory and file slug: kebab-case (e.g., `date-picker`)
 - Component export: PascalCase (e.g., `DatePicker`)
-- Variants const: camelCase + `Variants` suffix (e.g., `datePickerVariants`)
+- Variants const: camelCase + `Variants` suffix (e.g., `datePickerVariants`) — use `{nameCamel}` in templates
 - Data slot: kebab-case matching directory name
 
 ## Files to create
@@ -24,7 +24,7 @@ import * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
-const {name}Variants = cva(
+const {nameCamel}Variants = cva(
   '', // base classes
   {
     variants: {
@@ -43,21 +43,21 @@ const {name}Variants = cva(
 )
 
 export type {Name}Props = React.ComponentProps<'div'> &
-  VariantProps<typeof {name}Variants> & {
+  VariantProps<typeof {nameCamel}Variants> & {
     // Add custom props here
   }
 
 function {Name}({ className, variant, size, ...props }: {Name}Props) {
   return (
     <div
-      className={cn({name}Variants({ variant, size }), className)}
+      className={cn({nameCamel}Variants({ variant, size }), className)}
       data-slot="{kebab-name}"
       {...props}
     />
   )
 }
 
-export { {Name}, {name}Variants }
+export { {Name}, {nameCamel}Variants }
 ```
 
 Adapt the base HTML element (`div`, `button`, `input`, etc.) based on what the component represents. If wrapping a Radix UI primitive, import from `@radix-ui/react-*` and forward refs accordingly.

--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ dist
 .turbo
 
 # Claude
-.claude
+.claude/settings.*
 
 # Ring
 .ring/

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -1,0 +1,37 @@
+# Project Rules
+
+## Project Type
+
+TypeScript monorepo — frontend framework libraries (React components, Next.js server framework, logging, i18n tooling).
+
+## Tech Stack
+
+- TypeScript 5.9, React 19, Next.js 15
+- Inversify 7 (DI), Radix UI + Tailwind CSS 4 (components), Pino (logging)
+- Turborepo (build orchestration), Jest 30 (testing), Storybook 10 (docs)
+
+## Standards
+
+- TypeScript strict mode — no `any` unless justified with a comment
+- Conventional commits scoped to package names (`feat(sindarian-ui): ...`)
+- All public API through barrel files (`src/index.ts`)
+- Prettier enforced: 2-space indent, no semicolons, single quotes
+
+## Testing
+
+- Jest + ts-jest for all packages
+- @testing-library/react for UI components
+- Colocated test files: `{name}.test.ts(x)` next to source
+- Mock DI container and reflect-metadata in sindarian-server tests
+
+## Package Conventions
+
+- All published packages scoped under `@lerianstudio`
+- Peer dependencies for framework integrations (React, Next.js, Inversify)
+- Semantic versioning via Semantic Release
+- `develop` branch → beta prereleases, `main` branch → stable releases
+- Sequential releases to avoid npm publish conflicts
+
+## Inter-Package Contract
+
+`sindarian-logs` is a peer consumer of `sindarian-server`. Changes to server's public API (decorators, DI container, middleware interfaces) must be verified against logs.

--- a/packages/sindarian-i18n-cli/.claude/CLAUDE.md
+++ b/packages/sindarian-i18n-cli/.claude/CLAUDE.md
@@ -40,7 +40,8 @@ export default {
 - `extractAll()` → batch file processing with configurable concurrency
 - `validate()` → checks missing IDs, empty messages, duplicate ID conflicts
 - `diffKeys()` → compares extracted keys against existing locale JSON
-- Never throws — all errors collected in return values
+
+Error handling is split: `extractAll()`, `extractFile()`, and `validate()` collect errors in return values and never throw. However, `loadConfig()`, `loadConfigFromFile()`, and `diffKeys()` throw on invalid config or malformed locale files.
 
 ### Library API
 

--- a/packages/sindarian-i18n-cli/.claude/CLAUDE.md
+++ b/packages/sindarian-i18n-cli/.claude/CLAUDE.md
@@ -1,0 +1,53 @@
+## Sindarian i18n CLI
+
+i18n message extraction, validation, and key diffing. Uses `@formatjs/ts-transformer` under the hood.
+
+### CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `sindarian-i18n extract` | Extract messages and write locale JSON files |
+| `sindarian-i18n check` | Validate extracted messages (exit 1 on errors) |
+| `sindarian-i18n check-keys` | Diff extracted keys against locale file |
+
+Global option: `-c, --config <path>` for config file path.
+
+### Extraction Sources
+
+Recognized patterns (via @formatjs):
+- `defineMessages({ id, defaultMessage })`
+- `<FormattedMessage id="..." defaultMessage="..." />`
+- `formatMessage({ id, defaultMessage })`
+- Custom functions via `additionalFunctionNames` config
+
+### Config File
+
+Searched in order: `sindarian-i18n.config.{ts,js,cjs}`, `intl.config.{ts,js}`
+
+```typescript
+export default {
+  filePatterns: ['src/**/*.{ts,tsx}'],
+  defaultLocale: 'en',
+  locales: ['en', 'pt-BR'],
+  localeDir: 'src/locales',
+  additionalFunctionNames: [],  // optional
+  concurrency: 10               // optional
+}
+```
+
+### Architecture
+
+- `extractAll()` → batch file processing with configurable concurrency
+- `validate()` → checks missing IDs, empty messages, duplicate ID conflicts
+- `diffKeys()` → compares extracted keys against existing locale JSON
+- Never throws — all errors collected in return values
+
+### Library API
+
+All CLI functions exported from `@lerianstudio/sindarian-i18n-cli` for programmatic use: `extractAll`, `validate`, `diffKeys`, `loadConfig`, `formatSimpleJson`, etc.
+
+### Testing
+
+- Jest with `@jest-environment node`
+- Test source strings containing `defineMessages()` and `<FormattedMessage>`
+- Validate extraction results, error handling, offset calculations

--- a/packages/sindarian-logs/.claude/CLAUDE.md
+++ b/packages/sindarian-logs/.claude/CLAUDE.md
@@ -1,0 +1,46 @@
+## Sindarian Logs
+
+Request-scoped log aggregation for sindarian-server. One structured log entry per HTTP request with automatic trace IDs via AsyncLocalStorage.
+
+### Architecture
+
+- `TraceMiddleware` creates request context via `AsyncLocalStorage`
+- `LoggerAggregator` collects events during request lifecycle
+- `@Traceable()` decorator adds method-level events to current context
+- On completion: events aggregated, level escalated to highest severity, flushed via Pino
+
+### Public API
+
+**Decorators:**
+- `@Traceable(options?)` — Method decorator. Auto-derives operation as `ClassName.methodName`. Creates or joins request context.
+- `@LogHttpCall()` — For HTTP service hooks (`onBeforeFetch`, `onAfterFetch`, `catch`)
+
+**Functions:**
+- `withTrace(logger, name, fn)` — For non-class code (NextAuth callbacks, cron jobs, queue handlers)
+
+**Services:**
+- `LoggableHttpService` — Extends sindarian-server's `HttpService` with automatic HTTP call logging
+- `LoggerModule` — DI module providing all logging services + `TraceMiddleware` as `APP_MIDDLEWARE`
+
+### Key Patterns
+
+- Level escalation: final log level = highest severity event (`error > warn > audit > info > debug`)
+- Events capped at 1000 per request context
+- Debug events only recorded when `ENABLE_DEBUG=true`
+- `@Traceable()` disabled in `NODE_ENV=test`
+- `RequestIdRepository` generates UUID trace IDs via `AsyncLocalStorage`
+
+### Integration
+
+Peer dependency on `@lerianstudio/sindarian-server`. Add `LoggerModule` to your app:
+
+```typescript
+@Module({ imports: [LoggerModule], ... })
+class AppModule {}
+```
+
+### Testing
+
+- Mock `LoggerAggregator`: `jest.Mocked<Pick<LoggerAggregator, 'runWithContext'>>`
+- Mock impl: `jest.fn((_path, _method, _meta, fn) => fn())`
+- Test files colocated: `{name}.test.ts`

--- a/packages/sindarian-server/.claude/CLAUDE.md
+++ b/packages/sindarian-server/.claude/CLAUDE.md
@@ -1,0 +1,48 @@
+## Sindarian Server
+
+NestJS-inspired framework for Next.js. Decorator-based routing, DI via Inversify, middleware pipeline.
+
+### Architecture
+
+Execution pipeline: Guards → Pipes → Interceptors → Handler → Interceptor cleanup → Response
+
+Key abstractions:
+- **Controllers**: `@Controller(path)` + route decorators (`@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`)
+- **Guards**: `CanActivate` interface, applied via `@UseGuards()`
+- **Pipes**: `PipeTransform` interface, applied via `@UsePipes()`
+- **Interceptors**: `Interceptor` abstract class, applied via `@UseInterceptors()`
+- **Modules**: `@Module({ imports, controllers, providers })` for DI composition
+
+### Key Patterns
+
+- All decorators use `reflect-metadata` — `import 'reflect-metadata'` MUST be first line in `src/index.ts`
+- Metadata keys are Symbols defined in `src/constants/keys.ts`
+- Class-level decorators apply to all methods; method-level overrides class-level
+- Multi-provider tokens (`APP_GUARD`, `APP_INTERCEPTOR`, `APP_FILTER`, `APP_PIPE`, `APP_MIDDLEWARE`) accumulate across modules, they don't replace
+- Container resolution is async — always use `getAsync()`, not `get()`
+- `applyDecorators()` in `src/utils/` composes multiple decorators into one
+
+### Adding a New Decorator Type
+
+1. Add Symbol key in `src/constants/keys.ts`
+2. Create decorator function using `Reflect.defineMetadata(KEY, value, target)`
+3. Create Handler class with static methods: `getMetadata()`, `register()`, `fetch()`, `execute()`
+4. Export from feature barrel (e.g., `src/guards/index.ts`)
+5. Re-export from `src/index.ts`
+
+### Adding a Controller
+
+1. Create `src/controllers/{name}.controller.ts` with `@Controller(path)` + route decorators
+2. Register in a `@Module({ controllers: [...] })` 
+3. Exports are automatic via barrel re-exports
+
+### Subpath Exports
+
+- Main: `@lerianstudio/sindarian-server` — all framework exports
+- Zod: `@lerianstudio/sindarian-server/zod` — `createZodDto`, `ZodValidationPipe`
+
+### Testing
+
+- Jest + ts-jest, test files colocated: `{name}.test.ts`
+- Mock `reflect-metadata` and Inversify container in tests
+- Test pattern: verify metadata definition → handler registration → handler execution → edge cases

--- a/packages/sindarian-ui/.claude/CLAUDE.md
+++ b/packages/sindarian-ui/.claude/CLAUDE.md
@@ -1,0 +1,47 @@
+## Sindarian UI
+
+React component library built on Radix UI + ShadCN + Tailwind CSS + CVA.
+
+### Component Layers
+
+- **UI primitives** (`src/components/ui/`): Headless Radix wrappers with CVA styling
+- **Form fields** (`src/components/form/`): react-hook-form wrappers around UI primitives
+- **Composed** (`src/components/`): Higher-level components (Card, Dialog, Table, etc.)
+
+### Adding a UI Component
+
+1. Create `src/components/ui/{name}/index.tsx`
+2. Create `src/components/ui/{name}/{name}.stories.tsx`
+3. Create `src/components/ui/{name}/{name}.mdx`
+4. (Optional) Create `src/components/ui/{name}/styles.css` → import in `src/globals.css`
+5. Export in `src/index.tsx`: `export * from './components/ui/{name}'`
+
+### Adding a Form Field
+
+1. Create `src/components/form/{name}/index.tsx`
+2. Wrap UI component with `FormField` / `FormControl` / `FormItem` from `@/components/ui/form`
+3. Accept `control: Control<T>` from react-hook-form
+4. Use generic typing: `<T extends FieldValues = FieldValues>`
+5. Export in `src/components/form/index.ts`
+
+### Component Conventions
+
+- **CVA variants**: `cva('base-classes', { variants: {...}, defaultVariants: {...} })`
+- **Class merging**: Always use `cn()` from `@/lib/utils` (clsx + tailwind-merge)
+- **Data slot**: Always add `data-slot="component-name"` for CSS targeting
+- **Client directive**: `'use client'` at top of component files
+- **Props type**: `React.ComponentProps<'element'> & VariantProps<typeof variants> & custom`
+- **Compound exports**: Large components export sub-components (Select, SelectTrigger, SelectContent, etc.)
+
+### Storybook
+
+- Use `Meta<Props>` + `StoryObj<Props>` from `@storybook/nextjs`
+- Title paths: `Primitives/Button`, `Components/Form/InputField`
+- Form stories need a `BaseComponent` wrapper with `useForm()` + `<Form>`
+- MDX docs use `<Canvas of={Story.Name} />` pattern
+
+### Testing
+
+- `@testing-library/react` + Jest
+- `renderHook` + `act` for hooks
+- Test files: `{name}.test.ts` or `{name}.test.tsx`, colocated


### PR DESCRIPTION
## Summary

This pull request introduces new commands for an AI programming assistant to scaffold UI components, form fields, and new libraries within the monorepo. It also adds comprehensive project-level and package-specific documentation/guidelines, primarily for the AI assistant, but also includes a human-readable `PROJECT_RULES.md`. These files provide structured information about the monorepo's architecture, conventions, and development processes.

## Packages affected

- [x] Sindarian Server
- [x] Sindarian UI
- [x] Sindarian Logs
- [x] Sindarian i18n CLI
- [ ] Shared utils / configs
- [x] Root / CI / docs

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Breaking change
- [x] Documentation
- [x] CI / build / tooling

## Checklist

- [ ] I have tested these changes locally
- [ ] All tests pass (`npm test`)
- [ ] Linting passes (`npm run lint`)
- [x] Changes follow existing code conventions
- [x] I have updated documentation accordingly (if applicable)
- [ ] I have confirmed this code is ready for review

## Test plan

Verification for this change would involve:
- Confirming that the new `.claude/` files are correctly structured and provide clear instructions/information for an AI assistant.
- Testing the AI assistant's ability to interpret and execute the `/create-library`, `/create-ui-component`, and `/create-form-field` commands to ensure they generate the expected file structures and content.
- Verifying the `.gitignore` update correctly excludes `.claude/settings.*` without ignoring the entire `.claude` directory.

## Additional notes

This work is part of the "feature/ai-harness" initiative, aiming to empower an AI programming assistant with detailed project context and code generation capabilities. The `.claude/` directory contains structured documentation and command definitions specifically designed for the AI.

> **Reminder:** Always target your PR to the `develop` branch instead of `main`.