### PR TITLE
fix(sindarian-ui): align dropdown field text styles

### DIFF
--- a/packages/sindarian-ui/src/components/form/combo-box-field/index.tsx
+++ b/packages/sindarian-ui/src/components/form/combo-box-field/index.tsx
@@ -89,7 +89,7 @@ export const ComboBoxField = <T extends FieldValues = FieldValues>({
                 readOnly={readOnly}
                 tabIndex={0}
                 className={cn(
-                  'border-input-border bg-input hover:bg-input h-10 w-full justify-between rounded-md border px-4 py-2 pl-6 text-left text-sm font-normal focus:ring-2 focus:ring-offset-0 focus:outline-none',
+                  'border-input-border bg-input hover:bg-input text-foreground h-10 w-full justify-between rounded-md border px-4 py-2 pl-6 text-left text-base font-normal focus:ring-2 focus:ring-offset-0 focus:outline-none',
                   !field.value && 'text-muted-foreground'
                 )}
               >

--- a/packages/sindarian-ui/src/components/form/state-field/index.tsx
+++ b/packages/sindarian-ui/src/components/form/state-field/index.tsx
@@ -81,7 +81,7 @@ function StateComboBox({
           readOnly={readOnly}
           tabIndex={0}
           className={cn(
-            'border-input-border bg-input hover:bg-input h-10 w-full justify-between rounded-md border px-4 py-2 pl-6 text-left text-sm font-normal focus:ring-2 focus:ring-offset-0 focus:outline-none',
+            'border-input-border bg-input hover:bg-input text-foreground h-10 w-full justify-between rounded-md border px-4 py-2 pl-6 text-left text-base font-normal focus:ring-2 focus:ring-offset-0 focus:outline-none',
             !value && 'text-muted-foreground'
           )}
         >

--- a/packages/sindarian-ui/src/components/ui/select/styles.css
+++ b/packages/sindarian-ui/src/components/ui/select/styles.css
@@ -11,7 +11,7 @@
 
 @layer components {
   .select-trigger {
-    @apply h-select-h px-select-px py-select-py text-select-foreground border-select-border data-placeholder:text-select-placeholder flex w-full items-center justify-between rounded-md border text-sm font-medium focus:ring-2 focus:ring-offset-0 focus:outline-hidden focus-visible:outline-hidden;
+    @apply h-select-h px-select-px py-select-py text-select-foreground border-select-border data-placeholder:text-select-placeholder flex w-full items-center justify-between rounded-md border font-medium focus:ring-2 focus:ring-offset-0 focus:outline-hidden focus-visible:outline-hidden;
   }
 
   .select-read-only {


### PR DESCRIPTION
Use text-base and text-foreground on combo-box and state fields, and drop the text-sm override on the select trigger, so dropdown fields render consistently with other form inputs.

X-Lerian-Ref: 0x1

# Pull Request Checklist

## Pull Request Type

[//]: # 'Check the appropriate box for the type of pull request.'

- [ ] Sindarian Server
- [x] Sindarian UI

## Checklist

Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes

[//]: # 'Add any additional notes, context, or explanation that could be helpful for reviewers.'

## Obs: Please, always remember to target your PR to develop branch instead of main.
