### PR TITLE
chore: remove redundant shebang from CLI source

### DIFF
--- a/packages/sindarian-i18n-cli/src/cli.ts
+++ b/packages/sindarian-i18n-cli/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { Command } from 'commander'
 import path from 'path'
 import { mkdir, readFile, writeFile } from 'fs/promises'


### PR DESCRIPTION
tsup injects the shebang via banner.js, so the source-level #!/usr/bin/env node duplicated what the build already adds.

X-Lerian-Ref: 0x1

## Summary

<!-- Brief description of what this PR does and why -->

## Packages affected

- [ ] Sindarian Server
- [ ] Sindarian UI
- [ ] Sindarian Logs
- [x] Sindarian i18n CLI
- [ ] Shared utils / configs
- [ ] Root / CI / docs

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor (no functional change)
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / build / tooling

## Checklist

- [ ] I have tested these changes locally
- [ ] All tests pass (`npm test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Changes follow existing code conventions
- [ ] I have updated documentation accordingly (if applicable)
- [ ] I have confirmed this code is ready for review

## Test plan

<!-- How was this tested? What should reviewers verify? -->

## Additional notes

<!-- Add any context or explanation that could be helpful for reviewers -->

> **Reminder:** Always target your PR to the `develop` branch instead of `main`.
