### PR TITLE
fix(sindarian-i18n-cli): remove redundant shebang from CLI source

### DIFF
--- a/packages/sindarian-i18n-cli/src/cli.ts
+++ b/packages/sindarian-i18n-cli/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { Command } from 'commander'
 import path from 'path'
 import { mkdir, readFile, writeFile } from 'fs/promises'


### PR DESCRIPTION
## Summary

Removes the redundant `#!/usr/bin/env node` shebang from `src/cli.ts`. The shebang is injected by the tsup build (`banner`), so keeping it in the source is redundant.

Cherry-picked from `develop` (commit `2354fcb`) onto a branch off `main` to avoid the release-metadata conflicts (`package.json`/`CHANGELOG.md`) that block a direct `develop → main` merge.

## Packages affected

- [x] Sindarian i18n CLI

## Type of change

- [x] Bug fix

## Test plan

Net diff is a 2-line deletion in `src/cli.ts`; no functional/API change. tsup still emits the shebang in the built binary.