### PR TITLE
Fix/button aschild slottable

### DIFF
--- a/packages/sindarian-ui/src/components/ui/button/button.test.tsx
+++ b/packages/sindarian-ui/src/components/ui/button/button.test.tsx
@@ -1,0 +1,118 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { Button } from '.'
+
+/**
+ * Regression coverage for `asChild`.
+ *
+ * Button always renders three children (the two icon slots evaluate to `false`
+ * when no `icon` is given). Without a `Slottable` marking the real child, Radix
+ * Slot >=1.3.0 cannot tell which of the three to merge onto and throws
+ * "Slot failed to slot onto its children" — which broke `<Button asChild>` for
+ * every consumer, icon or not.
+ */
+describe('Button asChild', () => {
+  it('renders the child element instead of a button, with no icon', () => {
+    render(
+      <Button asChild variant="link">
+        <a href="/somewhere">Go somewhere</a>
+      </Button>
+    )
+
+    const link = screen.getByRole('link', { name: 'Go somewhere' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/somewhere')
+    // asChild must NOT leave a wrapping <button> around the anchor.
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('merges the button classes onto the child element', () => {
+    render(
+      <Button asChild variant="link" size="small" className="custom-class">
+        <a href="/x">Styled</a>
+      </Button>
+    )
+
+    const link = screen.getByRole('link', { name: 'Styled' })
+    expect(link).toHaveClass('custom-class')
+    expect(link).toHaveAttribute('data-slot', 'button')
+  })
+
+  it('keeps a start icon alongside the slotted child', () => {
+    render(
+      <Button asChild icon={<span data-testid="icon">*</span>}>
+        <a href="/x">With icon</a>
+      </Button>
+    )
+
+    const link = screen.getByRole('link', { name: /With icon/ })
+    expect(link).toBeInTheDocument()
+    // The icon renders inside the slotted element, not as a sibling of it.
+    expect(link).toContainElement(screen.getByTestId('icon'))
+  })
+
+  it('keeps an end icon alongside the slotted child', () => {
+    render(
+      <Button
+        asChild
+        icon={<span data-testid="icon">*</span>}
+        iconPlacement="end"
+      >
+        <a href="/x">Trailing</a>
+      </Button>
+    )
+
+    expect(screen.getByRole('link', { name: /Trailing/ })).toContainElement(
+      screen.getByTestId('icon')
+    )
+  })
+
+  it('accepts a child whose own content is multiple nodes', () => {
+    render(
+      <Button asChild variant="link">
+        <a href="/x">
+          <span aria-hidden="true">↩</span>
+          Back to list
+        </a>
+      </Button>
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Back to list' })
+    ).toBeInTheDocument()
+  })
+})
+
+describe('Button without asChild', () => {
+  it('still renders a native button (the Slottable path must be transparent)', () => {
+    render(<Button variant="primary">Click me</Button>)
+
+    const button = screen.getByRole('button', { name: 'Click me' })
+    expect(button.tagName).toBe('BUTTON')
+    expect(button).toHaveAttribute('data-slot', 'button')
+  })
+
+  it('still renders its icon', () => {
+    render(
+      <Button icon={<span data-testid="icon">*</span>}>Has an icon</Button>
+    )
+
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Has an icon/ })
+    ).toBeInTheDocument()
+  })
+
+  it('suppresses onClick when readOnly', () => {
+    const onClick = jest.fn()
+
+    render(
+      <Button readOnly onClick={onClick}>
+        Read only
+      </Button>
+    )
+
+    screen.getByRole('button', { name: 'Read only' }).click()
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sindarian-ui/src/components/ui/button/index.tsx
+++ b/packages/sindarian-ui/src/components/ui/button/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
+import { Slot, Slottable } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
@@ -95,7 +95,12 @@ function Button({
           {icon}
         </span>
       )}
-      {props.children}
+      {/*
+       * Required, not decoration: the icon slots always render (as `false`), so
+       * asChild's Slot sees 3 children and can't tell which to merge onto.
+       * Slottable marks the target; it's transparent when Comp is a 'button'.
+       */}
+      <Slottable>{props.children}</Slottable>
       {icon && iconPlacement !== 'start' && (
         <span className={cn(iconVariants({ position: iconPlacement, size }))}>
           {icon}

--- a/packages/sindarian-ui/src/components/ui/input/index.tsx
+++ b/packages/sindarian-ui/src/components/ui/input/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'
-import { useFormField } from '@/components/ui/form'
 import { cva, VariantProps } from 'class-variance-authority'
 
 const inputVariants = cva('input-base input-disabled input-read-only', {
@@ -46,7 +45,9 @@ export function Input({
   ref,
   ...props
 }: InputProps) {
-  const { formItemId } = useFormField()
+  // Fallback id so a standalone Input is still labelable. Inside a form,
+  // FormControl injects its own id through `props` below and overrides this.
+  const generatedId = React.useId()
   const [focus, setFocus] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
 
@@ -99,7 +100,7 @@ export function Input({
 
       <input
         ref={inputRef}
-        id={formItemId}
+        id={generatedId}
         data-slot="input"
         className={cn(
           inputVariants({

--- a/packages/sindarian-ui/src/components/ui/input/input.test.tsx
+++ b/packages/sindarian-ui/src/components/ui/input/input.test.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { useForm } from 'react-hook-form'
+import { Input } from '.'
+import { Form, FormControl, FormField, FormItem, FormLabel } from '../form'
+
+/**
+ * Regression coverage for standalone use.
+ *
+ * `Input` is a primitive with two callers: `InputField`, which wraps it in
+ * `FormField`/`FormItem`, and plain standalone use such as a search box. It
+ * used to call `useFormField`, which destructures `useFormContext()` — null
+ * with no provider above — so every standalone `<Input />` threw "Cannot
+ * destructure property 'getFieldState' of useFormContext(...) as it is null".
+ *
+ * It now reads no form context at all: a local `useId` covers the standalone
+ * case, and inside a form `FormControl`'s Slot injects the real id as a prop.
+ */
+describe('Input outside a form', () => {
+  it('renders with no react-hook-form provider', () => {
+    render(<Input placeholder="Search permissions by name..." />)
+
+    expect(
+      screen.getByPlaceholderText('Search permissions by name...')
+    ).toBeInTheDocument()
+  })
+
+  it('still gets an id so a label can be associated with it', () => {
+    render(<Input aria-label="Search" />)
+
+    expect(screen.getByRole('textbox', { name: 'Search' })).toHaveAttribute(
+      'id'
+    )
+  })
+
+  it('keeps value/onChange behaviour intact', () => {
+    const onChange = jest.fn()
+    render(<Input value="abc" onChange={onChange} aria-label="Search" />)
+
+    expect(screen.getByRole('textbox', { name: 'Search' })).toHaveValue('abc')
+  })
+})
+
+function FormHarness() {
+  const form = useForm({ defaultValues: { email: 'ada@example.com' } })
+
+  return (
+    <Form {...form}>
+      <FormField
+        control={form.control}
+        name="email"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>E-mail</FormLabel>
+            <FormControl>
+              <Input {...field} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+    </Form>
+  )
+}
+
+describe('Input inside a form', () => {
+  it('is still wired to its FormItem id, so the label points at it', () => {
+    render(<FormHarness />)
+
+    const input = screen.getByLabelText('E-mail')
+    expect(input).toHaveValue('ada@example.com')
+    // The id must come from FormItem's context, not the standalone fallback.
+    expect(input.getAttribute('id')).toMatch(/-form-item$/)
+  })
+})

--- a/packages/sindarian-ui/src/components/ui/input/input.test.tsx
+++ b/packages/sindarian-ui/src/components/ui/input/input.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { useForm } from 'react-hook-form'
 import { Input } from '.'
 import { Form, FormControl, FormField, FormItem, FormLabel } from '../form'
@@ -37,7 +37,15 @@ describe('Input outside a form', () => {
     const onChange = jest.fn()
     render(<Input value="abc" onChange={onChange} aria-label="Search" />)
 
-    expect(screen.getByRole('textbox', { name: 'Search' })).toHaveValue('abc')
+    const input = screen.getByRole('textbox', { name: 'Search' })
+    expect(input).toHaveValue('abc')
+
+    fireEvent.change(input, { target: { value: 'abcd' } })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ target: input })
+    )
   })
 })
 


### PR DESCRIPTION
# Description

Two regressions made `sindarian-ui` primitives unusable in common consumer patterns. Both are fixed here with regression coverage.

**`<Button asChild>` threw for every consumer.** `Button` always renders three children, because the two icon slots evaluate to `false` when no `icon` prop is passed. With no `Slottable` marking the real child, Radix Slot `>=1.3.0` cannot decide which child to merge onto and throws `Slot failed to slot onto its children` — regardless of whether an icon is used. The fix wraps `props.children` in `Slottable`, which is transparent when `Comp` is a native `button`, so the non-`asChild` path is unchanged.

**Standalone `<Input />` threw outside a form.** `Input` called `useFormField`, which destructures `useFormContext()`; that returns `null` with no provider above, so every non-form input — a search box, a filter field — threw `Cannot destructure property 'getFieldState' of useFormContext(...) as it is null`. The fix replaces it with a local `React.useId()` fallback. Inside a form, `FormControl`'s Slot still injects the real form-item id via `props`, which is spread after `id`, so label association inside forms is unchanged.

Also included: `Badge` `active`/`inactive` variants now draw real borders (`system-success-border`, `muted-foreground/40`) instead of `border-none`, icon-button CSS layout was tightened, and `SidebarItemIconButton` accepts `className` for per-call style overrides.

> **Stacked PR — read before reviewing.** This branch is cut from `feature/qrcode-and-copy-field` (open as **#117**), so the diff against `develop` also carries the four QRCode/CopyField commits reviewed there. Merge **#117** first; this diff then reduces to the two fix commits. Alternatively, retarget this PR's base to `feature/qrcode-and-copy-field` to review the fixes in isolation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) — QRCode and CopyField, inherited from #117
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Commits on this branch

| Commit | Message |
|--------|---------|
| `1c60735` | fix(sindarian-ui): drop form context from Input |
| `6e728a1` | fix(sindarian-ui): mark Button child as Slottable |
| `dcb2b6c` | feat(sindarian-ui): add CopyField component *(from #117)* |
| `91f92d1` | feat(sindarian-ui): add QRCode component *(from #117)* |
| `47f63f4` | fix(sindarian-ui): tighten badge borders and icon button layout *(from #117)* |
| `b239a04` | chore(sindarian-ui): add qrcode.react dependency *(from #117)* |

## Files changed

18 files, +993 / −37 against `develop`.

**New in this branch (the two fixes):**

| File | Change |
|------|--------|
| `src/components/ui/button/index.tsx` | Wrap `props.children` in `Slottable` |
| `src/components/ui/button/button.test.tsx` | New — 118 lines covering `asChild` and plain paths |
| `src/components/ui/input/index.tsx` | Drop `useFormField`, use `React.useId()` fallback |
| `src/components/ui/input/input.test.tsx` | New — 74 lines covering standalone and in-form callers |

**Inherited from #117:** `copy-field/*`, `qr-code/*`, `badge/index.tsx`, `icon-button/styles.css`, `sidebar/sidebar-item-icon-button.tsx`, `src/index.tsx`, `package.json`, `package-lock.json`.

## How to test

```bash
npx turbo test  --filter=@lerianstudio/sindarian-ui
npx turbo lint  --filter=@lerianstudio/sindarian-ui
npx turbo build --filter=@lerianstudio/sindarian-ui
```

> Run Jest against `src/` only. A stale `dist/` build makes Jest pick up duplicate compiled test copies that fail spuriously.

Manual checks:

1. `<Button asChild><a href="/x">Go</a></Button>` renders an `<a>` with the button classes and does not throw — with **and** without an `icon` prop.
2. A plain `<Button>Save</Button>` still renders a `<button>` with icons in the correct `iconPlacement` slots.
3. `<Input placeholder="Search" />` outside any `<Form>` renders without throwing.
4. Inside a form, an `InputField` label still focuses its input on click (id association intact).
5. `Badge` `active` and `inactive` variants show their new borders in both light and dark themes.

## Notes for reviewers

- The `Slottable` comment in `button/index.tsx` is load-bearing documentation: removing the wrapper silently breaks `asChild` again, and the cause (always-rendered `false` icon slots) is not obvious from the JSX.
- The `Input` id change relies on `{...props}` being spread **after** `id={generatedId}`. Reordering those props would break label association inside forms.
- `Badge`'s border change is global — every `active`/`inactive` badge across consuming apps picks up a visible border.
- If reviewing against `develop`, ignore the `qrcode.react` dependency and the QRCode/CopyField files; they belong to #117.
