### PR TITLE
ci: migrate workflow jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   # Detect which packages have changed
   get-changed-paths:
     name: Get Changed Paths
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
@@ -51,7 +51,7 @@ jobs:
   # Lint changed packages
   lint:
     name: Lint ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -79,7 +79,7 @@ jobs:
   # Run unit tests for changed packages
   test:
     name: Test ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -107,7 +107,7 @@ jobs:
   # Build changed packages to catch compilation errors
   build:
     name: Build ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
   get-changed-paths:
     if: github.actor != 'lerian-studio-midaz-push-bot[bot]'
     name: Get Changed Paths
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
@@ -63,7 +63,7 @@ jobs:
     name: Run npm audit
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -83,7 +83,7 @@ jobs:
   # Run tests for changed packages
   test:
     name: Test ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -108,7 +108,7 @@ jobs:
 
   test-e2e:
     name: Test E2E ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -134,7 +134,7 @@ jobs:
   # Release packages sequentially to avoid Git conflicts
   release:
     name: Release ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [get-changed-paths, npm-audit, test, test-e2e]
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:


### PR DESCRIPTION
The org is standardizing CI on Blacksmith runners, a drop-in replacement for GitHub-hosted runners that is roughly 2x faster at about half the per-minute price. This swaps the GitHub-hosted ubuntu labels for the same `blacksmith-4vcpu-ubuntu-2404` label the rest of the org uses; nothing else in the workflows changes.

```yaml
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
```