### PR TITLE
chore(ci): migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   # Detect which packages have changed
   get-changed-paths:
     name: Get Changed Paths
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
@@ -51,7 +51,7 @@ jobs:
   # Lint changed packages
   lint:
     name: Lint ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -79,7 +79,7 @@ jobs:
   # Run unit tests for changed packages
   test:
     name: Test ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -107,7 +107,7 @@ jobs:
   # Build changed packages to catch compilation errors
   build:
     name: Build ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
   get-changed-paths:
     if: github.actor != 'lerian-studio-midaz-push-bot[bot]'
     name: Get Changed Paths
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
@@ -63,7 +63,7 @@ jobs:
     name: Run npm audit
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -83,7 +83,7 @@ jobs:
   # Run tests for changed packages
   test:
     name: Test ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -108,7 +108,7 @@ jobs:
 
   test-e2e:
     name: Test E2E ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: get-changed-paths
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -134,7 +134,7 @@ jobs:
   # Release packages sequentially to avoid Git conflicts
   release:
     name: Release ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [get-changed-paths, npm-audit, test, test-e2e]
     if: needs.get-changed-paths.outputs.matrix != '[]'
     strategy:
@@ -272,7 +272,7 @@ jobs:
     if: needs.get-changed-paths.outputs.matrix != '[]' && github.ref_name == 'main'
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.18.1
     with:
-      runner_type: ubuntu-latest
+      runner_type: blacksmith-4vcpu-ubuntu-2404
       filter_paths: |
         packages/sindarian-server
         packages/sindarian-ui


### PR DESCRIPTION
Migrates this repository's GitHub Actions jobs from GitHub-hosted runners to Blacksmith runners, as part of the org-wide migration. Every hardcoded `ubuntu-*` label (both `runs-on:` and `runner_type:` inputs passed to shared workflows) now points to Blacksmith:

```yaml
runs-on: blacksmith-4vcpu-ubuntu-2404
```

Jobs pinned to `ubuntu-22.04` map to `blacksmith-4vcpu-ubuntu-2204` to keep the same OS version. Self-hosted labels (`eveo-*`, `self-hosted`) are untouched, and no other workflow logic changed.
