### PR TITLE
fix(sindarian-i18n-cli): sort non-default locale files

### DIFF
--- a/packages/sindarian-i18n-cli/src/cli.ts
+++ b/packages/sindarian-i18n-cli/src/cli.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { createRequire } from 'node:module'
 import { loadConfig } from './config'
-import { extractAll, formatSimpleJson } from './extractor'
+import { extractAll, formatLocaleJson, formatSimpleJson } from './extractor'
 import { validate } from './validator'
 import { diffKeys, formatKeyDiffReport } from './key-differ'
 import { formatValidationReport, formatExtractionErrors } from './reporter'
@@ -42,13 +42,12 @@ async function mergeLocale(
     }
   }
 
-  const merged: Record<string, string> = {}
-  for (const key of extractedKeys) {
-    merged[key] = existing[key] ?? ''
-  }
-
   try {
-    await writeFile(localePath, JSON.stringify(merged, null, 2), 'utf-8')
+    await writeFile(
+      localePath,
+      formatLocaleJson(extractedKeys, existing),
+      'utf-8'
+    )
   } catch (e) {
     console.error(
       `Failed to write locale file "${localePath}": ${(e as Error).message}`

--- a/packages/sindarian-i18n-cli/src/extractor.test.ts
+++ b/packages/sindarian-i18n-cli/src/extractor.test.ts
@@ -4,6 +4,7 @@
 import {
   calculateLineColFromOffset,
   extractFile,
+  formatLocaleJson,
   formatSimpleJson
 } from './extractor'
 import type { ExtractorConfig, ResolvedMessage } from './types'
@@ -171,5 +172,47 @@ describe('formatSimpleJson', () => {
   it('returns empty object for empty map', () => {
     const result = formatSimpleJson(new Map())
     expect(JSON.parse(result)).toEqual({})
+  })
+})
+
+describe('formatLocaleJson', () => {
+  it('sorts keys alphabetically regardless of extraction order', () => {
+    const result = formatLocaleJson(['zebra.message', 'alpha.message'], {
+      'zebra.message': 'Zebra',
+      'alpha.message': 'Alpha'
+    })
+
+    expect(Object.keys(JSON.parse(result))).toEqual([
+      'alpha.message',
+      'zebra.message'
+    ])
+    expect(result).toContain('  "alpha.message"')
+  })
+
+  it('produces identical output for any extraction order', () => {
+    const existing = { 'b.key': 'B', 'a.key': 'A', 'c.key': 'C' }
+
+    expect(formatLocaleJson(['c.key', 'a.key', 'b.key'], existing)).toBe(
+      formatLocaleJson(['a.key', 'b.key', 'c.key'], existing)
+    )
+  })
+
+  it('keeps existing translations and empties new keys', () => {
+    const result = formatLocaleJson(['a.key', 'b.key'], { 'a.key': 'Ola' })
+
+    expect(JSON.parse(result)).toEqual({ 'a.key': 'Ola', 'b.key': '' })
+  })
+
+  it('drops keys no longer in the extraction', () => {
+    const result = formatLocaleJson(['a.key'], {
+      'a.key': 'Ola',
+      'stale.key': 'Antigo'
+    })
+
+    expect(JSON.parse(result)).toEqual({ 'a.key': 'Ola' })
+  })
+
+  it('returns empty object when nothing was extracted', () => {
+    expect(JSON.parse(formatLocaleJson([], { 'a.key': 'Ola' }))).toEqual({})
   })
 })

--- a/packages/sindarian-i18n-cli/src/extractor.test.ts
+++ b/packages/sindarian-i18n-cli/src/extractor.test.ts
@@ -215,4 +215,34 @@ describe('formatLocaleJson', () => {
   it('returns empty object when nothing was extracted', () => {
     expect(JSON.parse(formatLocaleJson([], { 'a.key': 'Ola' }))).toEqual({})
   })
+
+  it('keeps an existing "__proto__" translation', () => {
+    // JSON.parse defines "__proto__" as an own data property, which is how a
+    // locale file reaches this function.
+    const existing = JSON.parse('{"__proto__":"Prototipo","a.key":"Ola"}')
+
+    const parsed = JSON.parse(
+      formatLocaleJson(['__proto__', 'a.key'], existing)
+    )
+
+    expect(parsed['__proto__']).toBe('Prototipo')
+    expect(parsed['a.key']).toBe('Ola')
+  })
+
+  it('empties a missing "__proto__" translation', () => {
+    const parsed = JSON.parse(
+      formatLocaleJson(['__proto__', 'a.key'], { 'a.key': 'Ola' })
+    )
+
+    expect(parsed['__proto__']).toBe('')
+    expect(Object.keys(parsed)).toEqual(['__proto__', 'a.key'])
+  })
+
+  it('empties ids that collide with inherited Object members', () => {
+    const parsed = JSON.parse(
+      formatLocaleJson(['toString', 'constructor', 'a.key'], { 'a.key': 'Ola' })
+    )
+
+    expect(parsed).toEqual({ toString: '', constructor: '', 'a.key': 'Ola' })
+  })
 })

--- a/packages/sindarian-i18n-cli/src/extractor.ts
+++ b/packages/sindarian-i18n-cli/src/extractor.ts
@@ -208,14 +208,19 @@ export function formatSimpleJson(
  *
  * Uses json-stable-stringify for the same alphabetical ordering as
  * formatSimpleJson, so output does not depend on file traversal order.
+ *
+ * The accumulator is null-prototype and lookups are own-property-only, so ids
+ * that collide with Object.prototype members ("__proto__", "toString", ...) are
+ * carried through as ordinary keys instead of being silently dropped.
  */
 export function formatLocaleJson(
   extractedKeys: string[],
   existing: Record<string, string>
 ): string {
-  const merged: Record<string, string> = {}
+  const merged: Record<string, string> = Object.create(null)
   for (const key of extractedKeys) {
-    merged[key] = existing[key] ?? ''
+    const translation = Object.hasOwn(existing, key) ? existing[key] : undefined
+    merged[key] = translation ?? ''
   }
   return stringify(merged, { space: 2 })
 }

--- a/packages/sindarian-i18n-cli/src/extractor.ts
+++ b/packages/sindarian-i18n-cli/src/extractor.ts
@@ -200,3 +200,22 @@ export function formatSimpleJson(
   }
   return stringify(simple, { space: 2 })
 }
+
+/**
+ * Formats a non-default locale as simple JSON: { [id]: translation }.
+ * Keeps existing translations, emits an empty string for keys that have none,
+ * and drops keys no longer present in the extraction.
+ *
+ * Uses json-stable-stringify for the same alphabetical ordering as
+ * formatSimpleJson, so output does not depend on file traversal order.
+ */
+export function formatLocaleJson(
+  extractedKeys: string[],
+  existing: Record<string, string>
+): string {
+  const merged: Record<string, string> = {}
+  for (const key of extractedKeys) {
+    merged[key] = existing[key] ?? ''
+  }
+  return stringify(merged, { space: 2 })
+}

--- a/packages/sindarian-i18n-cli/src/index.ts
+++ b/packages/sindarian-i18n-cli/src/index.ts
@@ -16,7 +16,8 @@ export {
   extractAll,
   extractFile,
   calculateLineColFromOffset,
-  formatSimpleJson
+  formatSimpleJson,
+  formatLocaleJson
 } from './extractor'
 
 // Validation


### PR DESCRIPTION
## What

`sindarian-i18n extract` wrote the default locale through `json-stable-stringify` (`formatSimpleJson`) but non-default locales through a plain `JSON.stringify` over the extraction `Map`. Key order in those files therefore followed **glob traversal order**, not alphabetical order.

The merge logic now lives in an exported `formatLocaleJson` that stringifies the same stable way, so every locale file is sorted and output is independent of traversal order.

## Why

Measured on `product-console` (6744 keys, `locales/extracted/`):

| File | Effect of a no-op `extract` |
|---|---|
| `en.json` (default locale) | byte-identical |
| `pt.json` (non-default) | **4688 of 6744 key positions move** |

That reorder is why the consuming repo cannot run `npm run extract:i18n` on a feature branch: a one-key change lands as a ~3000-line diff, so it maintains a bespoke scoped-extraction workaround instead. The order was also never guaranteed — it depended on filesystem traversal, so different machines could produce different files from the same source tree.

## Behaviour

Unchanged apart from key order:

- existing translations preserved
- new keys get `''`
- keys no longer extracted are dropped
- 2-space indent, no trailing newline

The first `extract` after upgrading produces a one-time sort diff per non-default locale file. Land that on its own commit.

## Tests

Five cases added for `formatLocaleJson` in `extractor.test.ts`, including order-independence (the same input in two orders produces identical output). 52 tests pass; `check-types`, `lint`, and `build` clean.

## Release note

`product-console` consumes the stable channel (`^1.0.1`), so this needs promotion to `main` before it is usable there.