### PR TITLE
fix(sindarian-ui): correct dialog padding and input placeholder

### DIFF
--- a/packages/sindarian-ui/src/components/ui/dialog/styles.css
+++ b/packages/sindarian-ui/src/components/ui/dialog/styles.css
@@ -9,11 +9,11 @@
   }
 
   .dialog-content {
-    @apply bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-8 border p-6 shadow-lg duration-200 sm:max-w-[425px] sm:rounded-lg;
+    @apply bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-8 border p-7 shadow-lg duration-200 sm:max-w-[425px] sm:rounded-lg;
   }
 
   .dialog-close {
-    @apply data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none;
+    @apply data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none;
   }
 
   .dialog-header {
@@ -25,7 +25,7 @@
   }
 
   .dialog-title {
-    @apply text-dialog-title-text text-lg font-bold leading-none tracking-tight;
+    @apply text-dialog-title-text text-lg leading-none font-bold tracking-tight;
   }
 
   .dialog-description {

--- a/packages/sindarian-ui/src/components/ui/input/styles.css
+++ b/packages/sindarian-ui/src/components/ui/input/styles.css
@@ -3,7 +3,7 @@
   --spacing-input-wrapper-p: calc(var(--spacing) * 2);
   --spacing-input-px: calc(var(--spacing) * 4);
   --color-input-foreground: var(--color-foreground);
-  --color-input-placeholder: var(--color-muted-foreground);
+  --color-input-placeholder: hsl(var(--input-placeholder));
   --color-input-border: var(--color-shadcn-400);
 
   --color-input-adornment: var(--color-container-text);
@@ -24,8 +24,12 @@
     @apply border-ring;
   }
 
+  /* Don't give the placeholder its own size or weight. At a smaller size it
+     still shares the input's baseline, so it rode ~0.75px below the value and
+     the text jumped the moment you typed; font-medium gave the hint the same
+     presence as the label naming the field. */
   .input-base {
-    @apply px-input-px text-input-foreground placeholder:text-input-placeholder h-full min-h-0 flex-1 border-none bg-transparent outline-none placeholder:text-sm placeholder:font-medium focus:ring-0 focus:ring-offset-0;
+    @apply px-input-px text-input-foreground placeholder:text-input-placeholder h-full min-h-0 flex-1 border-none bg-transparent outline-none focus:ring-0 focus:ring-offset-0;
   }
 
   .input-disabled {

--- a/packages/sindarian-ui/src/globals.css
+++ b/packages/sindarian-ui/src/globals.css
@@ -228,6 +228,10 @@
     --destructive-foreground: 0 0% 100%; /* white */
     --border: 240 5% 90%; /* base/200 = #E4E4E7 */
     --input: 0 0% 100%; /* base/white */
+    /* One step lighter than --muted-foreground, which is also the label colour:
+       a placeholder that matches its own label has no hierarchy left to give.
+       Still 4.4:1 on the shadcn-100 field, so it stays legible as a hint. */
+    --input-placeholder: 240 4% 46%; /* base/500 = #71717A */
     --ring: 240 5% 65%; /* focus ring */
     --radius: 0.5rem;
 
@@ -292,6 +296,10 @@
     --popover-foreground: 240 5% 96%; /* base/100 = #F4F4F5 */
     --border: 240 5% 34%; /* base/600 = #52525B */
     --input: 240 4% 16%; /* base/800 = #27272A */
+    /* Held at base/400 rather than stepped down with the light theme: on the
+       dark field that is already only 5.8:1, and going lighter here means
+       darker, which would push the hint under the AA floor. */
+    --input-placeholder: 240 5% 65%; /* base/400 = #A1A1AA */
     --primary: 240 5% 96%; /* base/100 = #F4F4F5 */
     --primary-foreground: 240 4% 16%; /* base/800 = #27272A */
     --secondary: 240 4% 16%; /* base/800 = #27272A */


### PR DESCRIPTION
## Summary

Two CSS-only visual fixes in `sindarian-ui`.

**Dialog content padding** — `.dialog-content` goes from `p-6` to `p-7`, so
content clears the absolutely-positioned close button and the header sits on a
more generous gutter. The commit also picks up Tailwind class-order
normalisation from the Prettier plugin (no behavioural effect).

**Input placeholder baseline** — the placeholder carried its own `text-sm` and
`font-medium`. At the smaller size it still shared the input's baseline, so it
rode ~0.75px below the value and the text visibly jumped the moment you typed;
the medium weight also gave the hint the same presence as the label naming the
field. Dropping both lets the placeholder inherit the value's metrics.

The placeholder colour moves to a dedicated `--input-placeholder` token instead
of reusing `--muted-foreground`, which is also the label colour — a placeholder
matching its own label has no hierarchy left to give. Light theme steps one
shade lighter (base/500, 4.4:1 on the field); dark theme deliberately holds at
base/400, because stepping "lighter" there means darker and would push the hint
under the AA floor. That asymmetry is intentional and commented in `globals.css`.

## Packages affected

- [ ] Sindarian Server
- [x] Sindarian UI
- [ ] Sindarian Logs
- [ ] Sindarian i18n CLI
- [ ] Shared utils / configs
- [ ] Root / CI / docs

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor (no functional change)
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / build / tooling

## Checklist

- [x] I have tested these changes locally
- [x] All tests pass (`npm test`)
- [ ] Linting passes (`npm run lint`) — deferred to CI, see Test plan
- [x] Changes follow existing code conventions
- [ ] I have updated documentation accordingly (if applicable)
- [x] I have confirmed this code is ready for review

## Test plan

`turbo test --filter=@lerianstudio/sindarian-ui` passes locally: 15 suites, 121
tests. Lint was **not** confirmed locally — this package's `lint` script is
`eslint . --fix` over the whole package and did not finish in a reasonable
window, so it is left to CI rather than ticked unverified. The diff is three
CSS files, none of which ESLint parses, so the risk is low.

These are presentational changes with no unit-test surface, so reviewers should
verify visually:

- **Dialog** — open any dialog story; confirm the body no longer crowds the
  close button and the padding reads even on all four sides.
- **Input placeholder, light theme** — the placeholder should sit on the same
  baseline as a typed value (no vertical shift on first keystroke), and should
  read one step lighter than the field's label rather than identical to it.
- **Input placeholder, dark theme** — confirm the hint is still comfortably
  legible; it is intentionally *not* stepped down to match the light theme.

## Additional notes

`--input-placeholder` is a new token in both theme blocks of `globals.css`.
Anything currently relying on the placeholder inheriting `--muted-foreground`
will now follow the new token instead — worth a glance if a downstream consumer
has overridden `--muted-foreground` expecting placeholders to track it.
