### PR TITLE
feat(sindarian-tokens): add the shared, WCAG-gated console token package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
             packages/sindarian-ui
             packages/sindarian-logs
             packages/sindarian-i18n-cli
+            packages/sindarian-tokens
           path-level: '2'
           get-app-name: 'true'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
           - sindarian-ui
           - sindarian-logs
           - sindarian-i18n-cli
+          - sindarian-tokens
           - all
 
 permissions:
@@ -56,6 +57,7 @@ jobs:
             packages/sindarian-ui
             packages/sindarian-logs
             packages/sindarian-i18n-cli
+            packages/sindarian-tokens
           path-level: '2'
           get-app-name: 'true'
 
@@ -278,6 +280,7 @@ jobs:
         packages/sindarian-ui
         packages/sindarian-logs
         packages/sindarian-i18n-cli
+        packages/sindarian-tokens
       path_level: '2'
       stable_releases_only: true
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ An i18n message extraction, validation, and key diffing CLI + library for React/
 
 ---
 
+### [@lerianstudio/sindarian-tokens](./packages/sindarian-tokens)
+
+The design tokens every Lerian internal console shares: one neutral colour ladder, in light and dark, gated at WCAG 2.2 AA.
+
+**Key Features**:
+
+- 🎨 Single source of truth for the internal-console identity (backoffice-console, caradhras)
+- 🌗 Light and dark palettes with the same token set, enforced
+- ♿ Every composed pair measured against its WCAG 2.2 AA floor on every test run, with no exemption list
+- 🧩 Tailwind v4 CSS-first entry (`tokens.css`) plus a Tailwind-free values-only entry (`palette.css`)
+- 📘 Token names exported as TypeScript constants for tooling
+
+[View Documentation →](./packages/sindarian-tokens)
+
+---
+
 ## ✨ Features
 
 - ✅ **Monorepo Structure** - Powered by npm workspaces and Turbo
@@ -127,6 +143,7 @@ Each package contains its own comprehensive documentation:
 - [**Sindarian UI Documentation**](./packages/sindarian-ui) - Component library with Storybook
 - [**Sindarian Logs Documentation**](./packages/sindarian-logs) - Logging and tracing system
 - [**Sindarian i18n CLI Documentation**](./packages/sindarian-i18n-cli) - i18n extraction and validation
+- [**Sindarian Tokens Documentation**](./packages/sindarian-tokens) - Shared, WCAG-gated console design tokens
 
 ---
 
@@ -139,6 +156,7 @@ console-sdk/
 │   ├── sindarian-ui/           # React component library
 │   ├── sindarian-logs/         # Logging and tracing system
 │   ├── sindarian-i18n-cli/     # i18n extraction and validation CLI
+│   ├── sindarian-tokens/       # Shared console design tokens (WCAG-gated)
 │   └── utils/                  # Shared utilities and base configs
 ├── package.json                # Root workspace configuration
 └── turbo.json                  # Turbo build configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@lerianstudio/sindarian-ui": "1.2.0-beta.5"
+        "@lerianstudio/sindarian-ui": "^1.2.0-beta.9"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.28.5",
@@ -4373,6 +4373,10 @@
     },
     "node_modules/@lerianstudio/sindarian-server": {
       "resolved": "packages/sindarian-server",
+      "link": true
+    },
+    "node_modules/@lerianstudio/sindarian-tokens": {
+      "resolved": "packages/sindarian-tokens",
       "link": true
     },
     "node_modules/@lerianstudio/sindarian-ui": {
@@ -25068,7 +25072,7 @@
     },
     "packages/sindarian-i18n-cli": {
       "name": "@lerianstudio/sindarian-i18n-cli",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@formatjs/ts-transformer": "^4.4.14",
@@ -25276,7 +25280,7 @@
     },
     "packages/sindarian-logs": {
       "name": "@lerianstudio/sindarian-logs",
-      "version": "1.1.0-beta.2",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@lerianstudio/sindarian-server": ">=1.1.0"
@@ -25313,7 +25317,7 @@
     },
     "packages/sindarian-server": {
       "name": "@lerianstudio/sindarian-server",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "path-to-regexp": "^8.4.2"
@@ -25325,9 +25329,22 @@
         "zod": ">=4.0.0"
       }
     },
+    "packages/sindarian-tokens": {
+      "name": "@lerianstudio/sindarian-tokens",
+      "version": "0.0.0",
+      "license": "ISC",
+      "peerDependencies": {
+        "tailwindcss": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "tailwindcss": {
+          "optional": true
+        }
+      }
+    },
     "packages/sindarian-ui": {
       "name": "@lerianstudio/sindarian-ui",
-      "version": "1.2.0-beta.7",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.2.1",

--- a/packages/sindarian-tokens/README.md
+++ b/packages/sindarian-tokens/README.md
@@ -1,0 +1,88 @@
+# @lerianstudio/sindarian-tokens
+
+The design tokens every Lerian internal console shares: one neutral colour
+ladder, in light and dark, gated at WCAG 2.2 AA.
+
+## Why this package exists
+
+The identity used to live as ~40 CSS custom properties inside
+`backoffice-console/apps/backoffice/src/app/globals.css`, with a hand-made copy
+of the same values in `caradhras/ui/src/styles.css`. Two copies and no contract:
+the first palette tweak on either side diverged silently, and nothing measured
+either one. This package is the single source both consoles import.
+
+It is **not** the Lerian-yellow product identity in
+`@lerianstudio/sindarian-ui`, which is a separate palette on purpose.
+
+## Install
+
+```bash
+npm install @lerianstudio/sindarian-tokens
+```
+
+## Use
+
+Tailwind v4 (CSS-first), which is what both consoles run — a Next app and a Vite
+SPA import it identically:
+
+```css
+@import 'tailwindcss';
+/* any component library that ships its own @theme goes here */
+@import '@lerianstudio/sindarian-tokens/tokens.css';
+```
+
+Import order matters: `tokens.css` carries an `@theme inline` block, and the
+last `@theme` mapping for a given slot wins. Putting it after the component
+library is what makes the console adopt this identity rather than the library's
+own.
+
+Then use the ordinary Tailwind utilities — `bg-background`, `text-foreground`,
+`text-muted-foreground`, `border-input`, `bg-destructive`, `rounded-lg` — and
+toggle dark mode by putting `class="dark"` on `<html>`.
+
+### Export surface
+
+| Entry | Contains | Needs Tailwind |
+| --- | --- | --- |
+| `@lerianstudio/sindarian-tokens/tokens.css` | `palette.css`, `--radius`, the `dark` custom variant, and the `@theme inline` mapping | yes |
+| `@lerianstudio/sindarian-tokens/palette.css` | only the `:root` and `.dark` colour declarations | no |
+| `@lerianstudio/sindarian-tokens` | `TOKEN_NAMES`, `THEMES`, `THEME_SELECTORS` for tooling and tests | no |
+
+`palette.css` is for a consumer that already owns its `@theme` mapping and wants
+only the values.
+
+### Values are colours, not triplets
+
+Each token holds a full colour (`--background: hsl(0 0% 100%)`), not the bare
+triplet (`0 0% 100%`) that backoffice stored and re-wrapped at every use site.
+The wrapper contract was implicit and unenforceable: forget it once and you get
+an invalid colour, and the token could not be used in `color-mix()` or in plain
+CSS. Consumers migrating from the triplet form must drop the `hsl(...)` wrapper
+from any hand-written `hsl(var(--token))`.
+
+## Accessibility
+
+Eight values deviate from the backoffice originals so that every pair a console
+composes clears its WCAG 2.2 AA floor — 4.5:1 for text (SC 1.4.3) and 3:1 for
+the focus ring and the field boundary (SC 1.4.11). Each deviation is annotated
+inline in `src/palette.css` with its before and after ratio.
+
+`--border` and `--sidebar-border` are deliberately left below 3:1. SC 1.4.11
+covers visual information required to identify a component or its state: a text
+field's boundary qualifies, so `--input` is gated at 3:1; a card edge, a section
+divider and a table rule do not, and shadcn paints `border-border` through a
+global `*` reset, so raising it would put a mid-grey stroke on every element in
+the product. They are measured against a visibility floor instead.
+
+`src/tokens.contrast.test.ts` re-measures every pair on every `npm test`, with
+no exemption list. If you change a value and a pair drops below its floor, fix
+the value — the threshold is not the thing to move.
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `npm run build` | type-check and emit `dist`, copying the stylesheets |
+| `npm run check-types` | type-check without emitting |
+| `npm test` | run the contrast gate |
+| `npm run lint` | ESLint with `--fix` |

--- a/packages/sindarian-tokens/eslint.config.mjs
+++ b/packages/sindarian-tokens/eslint.config.mjs
@@ -1,0 +1,9 @@
+import baseConfig from '../utils/eslint.config.mjs'
+
+export default [
+  ...baseConfig,
+
+  {
+    ignores: ['dist/**', '**/dist/**', 'coverage/**']
+  }
+]

--- a/packages/sindarian-tokens/jest.config.ts
+++ b/packages/sindarian-tokens/jest.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from 'jest'
+import baseConfig from '../utils/jest.config'
+
+const config: Config = {
+  ...baseConfig,
+  displayName: 'sindarian-tokens',
+  testEnvironment: 'node',
+
+  // src/__tests__/contrast.ts is the measurement instrument, not a suite.
+  // ts-jest's default testMatch would claim it and fail it as an empty suite.
+  testMatch: ['**/*.test.ts'],
+
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: './tsconfig.eslint.json'
+      }
+    ]
+  },
+  setupFilesAfterEnv: undefined
+}
+
+export default config

--- a/packages/sindarian-tokens/package.json
+++ b/packages/sindarian-tokens/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@lerianstudio/sindarian-tokens",
+  "version": "0.0.0",
+  "description": "Shared design tokens for Lerian internal consoles — the neutral colour ladder, WCAG 2.2 AA gated",
+  "license": "ISC",
+  "author": {
+    "name": "Lerian Studio",
+    "email": "contato@lerian.studio",
+    "url": "https://lerian.studio"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LerianStudio/console-sdk.git",
+    "directory": "packages/sindarian-tokens"
+  },
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./tokens.css": "./dist/tokens.css",
+    "./palette.css": "./dist/palette.css"
+  },
+  "scripts": {
+    "build": "tsc && npm run copy:styles && npm run build:paths",
+    "build:paths": "tsc-alias -p tsconfig.json",
+    "copy:styles": "copyfiles -u 1 src/**/*.css dist",
+    "check-types": "tsc --noEmit",
+    "test": "jest",
+    "test:e2e": "exit 0",
+    "test:cov": "jest --coverage",
+    "lint": "eslint . --fix",
+    "lint:check": "eslint ."
+  },
+  "peerDependencies": {
+    "tailwindcss": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sindarian-tokens/src/__tests__/contrast.ts
+++ b/packages/sindarian-tokens/src/__tests__/contrast.ts
@@ -1,0 +1,201 @@
+/**
+ * WCAG contrast measurement over the colour tokens declared in palette.css.
+ *
+ * WHY MEASURE THE TOKENS RATHER THAN A RENDER
+ *
+ * The obvious alternative is axe-core over a mounted tree, and it does not
+ * work: axe resolves contrast by rasterising the element stack onto a canvas,
+ * jsdom has no canvas, so `color-contrast` lands in axe's `incomplete` bucket
+ * while `toHaveNoViolations()` reads only `violations`. White on white passes
+ * such a suite. The other alternative, a Playwright probe, only measures the
+ * pairs the visited pages happen to paint — which would miss every status fill.
+ *
+ * Reading the declarations covers every pair in both themes on every run,
+ * including pairs no consumer has built yet. What it does NOT cover is listed
+ * in the header of tokens.contrast.test.ts; read that before trusting it.
+ *
+ * 8-BIT ROUNDING IS DELIBERATE
+ *
+ * `hslToRgb` rounds each channel before luminance, because a browser resolves
+ * `hsl(0 0% 44%)` to `rgb(112, 112, 112)` and paints that — devtools and axe
+ * both report the painted value. Unrounded arithmetic drifts from what a
+ * reviewer sees in the browser.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { THEMES, THEME_SELECTORS, type Theme } from '../index'
+
+export type Rgb = readonly [number, number, number]
+
+export type TokenSheet = Record<Theme, Readonly<Record<string, string>>>
+
+export { THEMES, THEME_SELECTORS }
+export type { Theme }
+
+export function hslToRgb(h: number, s: number, l: number): Rgb {
+  const sat = s / 100
+  const light = l / 100
+  const a = sat * Math.min(light, 1 - light)
+  const channel = (n: number) => {
+    const k = (n + h / 30) % 12
+    return light - a * Math.max(-1, Math.min(k - 3, Math.min(9 - k, 1)))
+  }
+  return [
+    Math.round(channel(0) * 255),
+    Math.round(channel(8) * 255),
+    Math.round(channel(4) * 255)
+  ] as const
+}
+
+export function hexToRgb(hex: string): Rgb {
+  const body = hex.slice(1)
+  const full =
+    body.length === 3
+      ? body
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : body
+  return [
+    parseInt(full.slice(0, 2), 16),
+    parseInt(full.slice(2, 4), 16),
+    parseInt(full.slice(4, 6), 16)
+  ] as const
+}
+
+/** WCAG 2.x relative luminance (sRGB, D65). */
+export function relativeLuminance([r, g, b]: Rgb): number {
+  const linear = [r, g, b].map((v) => {
+    const c = v / 255
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+  }) as [number, number, number]
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+}
+
+/**
+ * WCAG 2.x contrast ratio, in [1, 21]. Order-independent by construction, so a
+ * caller cannot get a wrong answer by passing foreground and background the
+ * other way round.
+ */
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a)
+  const lb = relativeLuminance(b)
+  const [lighter, darker] = la > lb ? [la, lb] : [lb, la]
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+const HSL =
+  /^hsl\(\s*(-?[\d.]+)(?:deg)?\s*[, ]\s*([\d.]+)%\s*[, ]\s*([\d.]+)%\s*\)$/
+const HEX = /^#(?:[\da-f]{3}|[\da-f]{6})$/i
+
+/**
+ * Parse one declaration value into the colour a browser paints.
+ *
+ * Throws rather than returning null. A token this gate asks for and cannot read
+ * is a hole in the gate, and a hole must be loud — that covers the realistic
+ * regressions (a token moved to `oklch()`, to a `var()` indirection, or given
+ * an alpha channel), each of which would otherwise drop its pair silently.
+ */
+export function parseColor(value: string, context: string): Rgb {
+  const raw = value.trim()
+  const hsl = HSL.exec(raw)
+  if (hsl) {
+    return hslToRgb(Number(hsl[1]), Number(hsl[2]), Number(hsl[3]))
+  }
+  if (HEX.test(raw)) {
+    return hexToRgb(raw)
+  }
+  throw new Error(
+    `${context}: expected an hsl() literal or a hex colour this gate can measure, got "${raw}". ` +
+      `If the palette moved to another colour space, teach src/__tests__/contrast.ts to read it — ` +
+      `do not drop the pair from the gate.`
+  )
+}
+
+/**
+ * Pull the `:root` and `.dark` declaration blocks out of a stylesheet.
+ *
+ * Neither block nests, so a flat `selector { body }` scan suffices; blocks that
+ * do nest never produce a chunk whose selector is exactly `:root` or `.dark`.
+ * Comments are stripped first — palette.css carries long prose comments that
+ * mention selectors and colour functions.
+ *
+ * Exactly one block per theme is required: two `:root` blocks would mean later
+ * declarations silently win over the ones this gate measured.
+ */
+export function parseTokenSheet(css: string): TokenSheet {
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, '')
+  const found: Record<string, Record<string, string>[]> = {
+    ':root': [],
+    '.dark': []
+  }
+
+  for (const [, selector = '', body = ''] of stripped.matchAll(
+    /([^{}]*)\{([^{}]*)\}/g
+  )) {
+    const name = (selector.split(';').pop() ?? '').trim()
+    const bucket = found[name]
+    if (!bucket) continue
+    const declarations: Record<string, string> = {}
+    for (const [, token = '', value = ''] of body.matchAll(
+      /(--[\w-]+)\s*:\s*([^;]+);/g
+    )) {
+      declarations[token] = value.trim()
+    }
+    bucket.push(declarations)
+  }
+
+  const sheet = {} as Record<Theme, Record<string, string>>
+  for (const theme of THEMES) {
+    const selector = THEME_SELECTORS[theme]
+    const blocks = found[selector] ?? []
+    if (blocks.length !== 1) {
+      throw new Error(
+        `expected exactly one \`${selector}\` block in the stylesheet, found ${blocks.length}`
+      )
+    }
+    sheet[theme] = blocks[0] as Record<string, string>
+  }
+  return sheet
+}
+
+export const PALETTE_PATH = join(__dirname, '..', 'palette.css')
+
+export function readTokenSheet(path: string = PALETTE_PATH): TokenSheet {
+  return parseTokenSheet(readFileSync(path, 'utf8'))
+}
+
+/**
+ * Resolve a bare token name (`foreground`, not `--foreground`) to a colour.
+ * A token missing from a theme throws: deleting a declaration does not break a
+ * build, the slot just falls back to whatever the consuming component library
+ * defines — unmeasured and unreviewed.
+ */
+export function resolveToken(
+  sheet: TokenSheet,
+  theme: Theme,
+  token: string
+): Rgb {
+  const value = sheet[theme][`--${token}`]
+  if (value === undefined) {
+    throw new Error(
+      `--${token} is not declared in the ${theme} palette (${THEME_SELECTORS[theme]}). ` +
+        `Without a declaration the slot falls back to the consuming library's default, ` +
+        `which this gate never sees.`
+    )
+  }
+  return parseColor(value, `--${token} (${theme})`)
+}
+
+export function tokenContrast(
+  sheet: TokenSheet,
+  theme: Theme,
+  fg: string,
+  bg: string
+): number {
+  return contrastRatio(
+    resolveToken(sheet, theme, fg),
+    resolveToken(sheet, theme, bg)
+  )
+}

--- a/packages/sindarian-tokens/src/index.ts
+++ b/packages/sindarian-tokens/src/index.ts
@@ -1,0 +1,59 @@
+export const THEMES = ['light', 'dark'] as const
+
+export type Theme = (typeof THEMES)[number]
+
+export const THEME_SELECTORS: Readonly<Record<Theme, string>> = {
+  light: ':root',
+  dark: '.dark'
+}
+
+/**
+ * Every colour token palette.css declares, in both themes.
+ *
+ * This list is the package's public contract, not documentation: the contrast
+ * suite asserts it matches the `:root` and `.dark` blocks exactly, in both
+ * directions, so a token added to the stylesheet without being added here (or
+ * vice versa) fails the build.
+ */
+export const TOKEN_NAMES = [
+  'background',
+  'foreground',
+  'card',
+  'card-foreground',
+  'popover',
+  'popover-foreground',
+  'primary',
+  'primary-foreground',
+  'secondary',
+  'secondary-foreground',
+  'muted',
+  'muted-foreground',
+  'accent',
+  'accent-foreground',
+  'destructive',
+  'destructive-foreground',
+  'success',
+  'success-foreground',
+  'warning',
+  'warning-foreground',
+  'info',
+  'info-foreground',
+  'border',
+  'input',
+  'ring',
+  'sidebar',
+  'sidebar-foreground',
+  'sidebar-accent',
+  'sidebar-accent-foreground',
+  'sidebar-border',
+  'shadcn-100',
+  'shadcn-200',
+  'shadcn-300',
+  'shadcn-400',
+  'shadcn-500',
+  'shadcn-600',
+  'shadcn-700',
+  'shadcn-800'
+] as const
+
+export type TokenName = (typeof TOKEN_NAMES)[number]

--- a/packages/sindarian-tokens/src/palette.css
+++ b/packages/sindarian-tokens/src/palette.css
@@ -1,0 +1,176 @@
+/*
+ * Lerian internal-console palette — the neutral token ladder shared by every
+ * Lerian admin console (backoffice-console, caradhras).
+ *
+ * SOURCE AND SCOPE
+ *
+ * The values below originate in backoffice-console's app stylesheet
+ * (apps/backoffice/src/app/globals.css), which was the de-facto source of
+ * truth: caradhras carried a hand-made copy of it, so the first palette tweak
+ * on either side diverged silently. This file replaces both copies.
+ *
+ * This is NOT the Lerian-yellow product identity in @lerianstudio/sindarian-ui;
+ * that palette is a separate, deliberately different thing.
+ *
+ * COLOURS ONLY, ONE `:root` AND ONE `.dark`
+ *
+ * Every declaration here is a colour, and both blocks declare exactly the same
+ * token set — the contrast gate asserts both properties, because a token
+ * declared in one theme only falls back to whatever the component library
+ * happens to define, unmeasured. Non-colour tokens (`--radius`) and the
+ * Tailwind `@theme` mapping live in tokens.css.
+ *
+ * VALUES ARE FULL `hsl()` LITERALS, NOT BARE TRIPLETS
+ *
+ * backoffice stored bare triplets (`0 0% 100%`) and wrapped them at every use
+ * site (`hsl(var(--background))`). That contract is implicit and unenforceable:
+ * a consumer that forgets the wrapper gets an invalid colour, and the token is
+ * unusable in `color-mix()` or in plain CSS. Here each token is already a
+ * colour.
+ *
+ * WCAG
+ *
+ * Eight values deviate from the backoffice originals to clear a WCAG 2.2 AA
+ * floor; each deviation is annotated inline with the before/after ratio, and
+ * every pair is re-measured on each test run by tokens.contrast.test.ts.
+ */
+
+:root {
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(0 0% 4%);
+
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(0 0% 4%);
+
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(0 0% 4%);
+
+  --primary: hsl(0 0% 9%);
+  --primary-foreground: hsl(0 0% 98%);
+
+  --secondary: hsl(0 0% 96%);
+  --secondary-foreground: hsl(0 0% 9%);
+
+  --muted: hsl(0 0% 96%);
+  /* SC 1.4.3. Was 0 0% 45%: 4.35:1 on --muted, short of 4.5:1. One point of
+     lightness is the whole fix (4.54:1), and it lifts the same ink on the
+     canvas from 4.74:1 to 4.95:1. */
+  --muted-foreground: hsl(0 0% 44%);
+
+  --accent: hsl(0 0% 96%);
+  --accent-foreground: hsl(0 0% 9%);
+
+  /* SC 1.4.3. Was 0 84% 60% (red-500): near-white ink measured 3.62:1. The ink
+     stays near-white — white-on-red is what a destructive control reads as —
+     so the fill absorbs the change, one step down its own hue to 4.67:1. */
+  --destructive: hsl(0 84% 48%);
+  --destructive-foreground: hsl(0 0% 98%);
+
+  /* SC 1.4.3. Was 147 75% 34%: white ink measured 3.72:1. Four points of
+     lightness reach 4.64:1. */
+  --success: hsl(147 75% 30%);
+  --success-foreground: hsl(0 0% 100%);
+
+  --warning: hsl(37 95% 49%);
+  --warning-foreground: hsl(0 0% 0%);
+
+  /* SC 1.4.3. Was 217 91% 60% (blue-500): white ink measured 3.64:1. Seven
+     points down, near blue-600, reaches 4.58:1. */
+  --info: hsl(217 91% 53%);
+  --info-foreground: hsl(0 0% 100%);
+
+  /* Decorative boundary — card edges, separators, table rules. Deliberately
+     left at 1.25:1 against its surfaces; see the DECORATIVE note in
+     tokens.contrast.test.ts for why SC 1.4.11 does not reach it. */
+  --border: hsl(0 0% 90%);
+  /* SC 1.4.11. Was 0 0% 90%: 1.25:1, so the boundary of a text field was
+     effectively invisible against the page. This token is the field boundary
+     (`border-input` on Input, Textarea, Select, outline Button) and the
+     unchecked Switch track, all of which identify a component or its state.
+     0 0% 55% clears 3:1 against every surface in the palette: background and
+     card 3.36:1, sidebar 3.22:1, muted 3.08:1. */
+  --input: hsl(0 0% 55%);
+  --ring: hsl(0 0% 9%);
+
+  --sidebar: hsl(0 0% 98%);
+  --sidebar-foreground: hsl(0 0% 4%);
+  --sidebar-accent: hsl(0 0% 96%);
+  --sidebar-accent-foreground: hsl(0 0% 9%);
+  /* Decorative, as --border. */
+  --sidebar-border: hsl(0 0% 90%);
+
+  --shadcn-100: #f4f4f5;
+  --shadcn-200: #e4e4e7;
+  --shadcn-300: #d4d4d8;
+  --shadcn-400: #a1a1aa;
+  --shadcn-500: #71717a;
+  --shadcn-600: #27272a;
+  --shadcn-700: #18181b;
+  --shadcn-800: #09090b;
+}
+
+.dark {
+  --background: hsl(0 0% 4%);
+  --foreground: hsl(0 0% 98%);
+
+  --card: hsl(0 0% 4%);
+  --card-foreground: hsl(0 0% 98%);
+
+  --popover: hsl(0 0% 4%);
+  --popover-foreground: hsl(0 0% 98%);
+
+  --primary: hsl(0 0% 98%);
+  --primary-foreground: hsl(0 0% 9%);
+
+  --secondary: hsl(0 0% 15%);
+  --secondary-foreground: hsl(0 0% 98%);
+
+  --muted: hsl(0 0% 15%);
+  --muted-foreground: hsl(0 0% 64%);
+
+  --accent: hsl(0 0% 15%);
+  --accent-foreground: hsl(0 0% 98%);
+
+  --destructive: hsl(0 63% 31%);
+  --destructive-foreground: hsl(0 0% 98%);
+
+  /* SC 1.4.3. The fill is untouched: green-500 is the dark theme's accent and
+     darkening it to carry white ink (it would need 142 71% 31%) would put a
+     dark badge on a near-black canvas. The ink flips instead, exactly as
+     --warning-foreground already does on the equally light amber. White
+     measured 2.30:1; black measures 9.12:1. */
+  --success: hsl(142 71% 45%);
+  --success-foreground: hsl(0 0% 0%);
+
+  --warning: hsl(37 95% 49%);
+  --warning-foreground: hsl(0 0% 0%);
+
+  /* SC 1.4.3, same reasoning as --success above. White measured 2.52:1 on this
+     blue-400 fill; black measures 8.34:1, and the fill is unchanged. */
+  --info: hsl(213 94% 68%);
+  --info-foreground: hsl(0 0% 0%);
+
+  /* Decorative boundary, as in the light palette. */
+  --border: hsl(0 0% 15%);
+  /* SC 1.4.11. Was 0 0% 15%: 1.31:1 against the canvas and 1.00:1 against a
+     --muted fill — the boundary of a field inside a muted well did not exist.
+     0 0% 44% measures 4.00:1 against background, card, popover and sidebar,
+     and 3.06:1 against muted. */
+  --input: hsl(0 0% 44%);
+  --ring: hsl(0 0% 83%);
+
+  --sidebar: hsl(0 0% 4%);
+  --sidebar-foreground: hsl(0 0% 98%);
+  --sidebar-accent: hsl(0 0% 15%);
+  --sidebar-accent-foreground: hsl(0 0% 98%);
+  --sidebar-border: hsl(0 0% 15%);
+
+  --shadcn-100: #27272a;
+  --shadcn-200: #3f3f46;
+  --shadcn-300: #52525b;
+  --shadcn-400: #a1a1aa;
+  --shadcn-500: #d4d4d8;
+  --shadcn-600: #e4e4e7;
+  --shadcn-700: #f4f4f5;
+  --shadcn-800: #fafafa;
+}

--- a/packages/sindarian-tokens/src/tokens.contrast.test.ts
+++ b/packages/sindarian-tokens/src/tokens.contrast.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Colour-contrast gate for the Lerian internal-console palette.
+ *
+ * This suite is the reason the palette lives in a package instead of in two
+ * app stylesheets. It does not render: it reads the declarations out of
+ * palette.css and computes WCAG 2.2 ratios directly, so every pair in both
+ * themes is measured on every `npm test`, including pairs on screens that no
+ * consumer has built yet.
+ *
+ * THERE IS NO RATCHET HERE, AND THAT IS THE POINT
+ *
+ * The gate this one replaces (caradhras `ui/src/styles.contrast.test.ts`)
+ * carried a KNOWN_SHORTFALLS list freezing fourteen pairs at the ratios they
+ * happened to measure, because fixing them meant changing a palette that lived
+ * in someone else's app. The palette lives here now, so every pair is held to
+ * its real WCAG floor and there is nothing to exempt. Do not reintroduce an
+ * exemption list: lowering a floor to make a build green is the failure mode
+ * this file exists to prevent.
+ *
+ * WHAT THIS GATE DOES NOT COVER — read before trusting it
+ *
+ *  - Alpha compositing. Consumers paint `bg-success/10`, `bg-muted/30` and
+ *    similar tinted fills; a ratio against the flat token is not the ratio
+ *    against the blend. Those need a rendered measurement.
+ *  - Cascade and specificity. This reads the declared value, not the value that
+ *    wins at a given node after a component library's own sheet and Tailwind
+ *    utilities.
+ *  - Text over images, gradients and shadows.
+ *  - Font size and weight. WCAG relaxes to 3:1 for large text (>=18.66px bold /
+ *    >=24px), but a colour token carries no size — the same
+ *    `--muted-foreground` prints 12px captions and 24px numerals — so every
+ *    text pair is held to the stricter 4.5:1.
+ */
+import {
+  THEMES,
+  contrastRatio,
+  hexToRgb,
+  hslToRgb,
+  parseTokenSheet,
+  readTokenSheet,
+  resolveToken,
+  tokenContrast,
+  type Theme
+} from './__tests__/contrast'
+import { TOKEN_NAMES } from './index'
+
+/**
+ * WCAG 2.2 AA floors.
+ *
+ * `text` (SC 1.4.3, 4.5:1) applies to every foreground/surface pair.
+ * `nonText` (SC 1.4.11, 3:1) applies to pairs that carry no glyphs but do carry
+ * information required to identify a component or its state: the focus ring and
+ * the field boundary.
+ */
+const THRESHOLDS = { text: 4.5, nonText: 3 } as const
+
+type Kind = keyof typeof THRESHOLDS
+
+type Pair = {
+  fg: string
+  bg: string
+  kind: Kind
+  /** Where this composition actually renders. */
+  why: string
+}
+
+/**
+ * Every foreground/background pair a console composes.
+ *
+ * Membership is evidence-based, not symmetrical: an `--x` / `--x-foreground`
+ * slot earns a row only if something paints the fill solid. Note that
+ * `--warning-foreground` is black while several siblings are white — a gate
+ * that assumed a uniform near-white ink would measure white-on-amber (2.23:1)
+ * and fail a pair that is in fact fine (9.41:1).
+ */
+const PAIRS: readonly Pair[] = [
+  {
+    fg: 'foreground',
+    bg: 'background',
+    kind: 'text',
+    why: 'body copy on the page canvas'
+  },
+  {
+    fg: 'card-foreground',
+    bg: 'card',
+    kind: 'text',
+    why: 'body copy inside Card'
+  },
+  {
+    fg: 'popover-foreground',
+    bg: 'popover',
+    kind: 'text',
+    why: 'body copy inside Popover / DropdownMenu'
+  },
+
+  {
+    fg: 'muted-foreground',
+    bg: 'background',
+    kind: 'text',
+    why: 'page subtitles and helper text on the canvas'
+  },
+  {
+    fg: 'muted-foreground',
+    bg: 'card',
+    kind: 'text',
+    why: 'secondary text inside Card'
+  },
+  {
+    fg: 'muted-foreground',
+    bg: 'muted',
+    kind: 'text',
+    why: 'secondary text on a muted fill'
+  },
+  {
+    fg: 'muted-foreground',
+    bg: 'secondary',
+    kind: 'text',
+    why: 'secondary text on a secondary fill'
+  },
+  {
+    fg: 'muted-foreground',
+    bg: 'sidebar',
+    kind: 'text',
+    why: 'secondary text in the sidebar'
+  },
+
+  {
+    fg: 'primary-foreground',
+    bg: 'primary',
+    kind: 'text',
+    why: 'primary Button label'
+  },
+  {
+    fg: 'secondary-foreground',
+    bg: 'secondary',
+    kind: 'text',
+    why: 'secondary Button / Badge label'
+  },
+  {
+    fg: 'accent-foreground',
+    bg: 'accent',
+    kind: 'text',
+    why: 'hovered or selected row and menu item'
+  },
+
+  {
+    fg: 'destructive-foreground',
+    bg: 'destructive',
+    kind: 'text',
+    why: 'destructive Button / Badge label'
+  },
+  {
+    fg: 'success-foreground',
+    bg: 'success',
+    kind: 'text',
+    why: 'success Badge label'
+  },
+  {
+    fg: 'warning-foreground',
+    bg: 'warning',
+    kind: 'text',
+    why: 'warning Badge label — black ink, unlike some siblings'
+  },
+  { fg: 'info-foreground', bg: 'info', kind: 'text', why: 'info Badge label' },
+
+  {
+    fg: 'sidebar-foreground',
+    bg: 'sidebar',
+    kind: 'text',
+    why: 'navigation item label'
+  },
+  {
+    fg: 'sidebar-accent-foreground',
+    bg: 'sidebar-accent',
+    kind: 'text',
+    why: 'active or hovered navigation item'
+  },
+
+  {
+    fg: 'ring',
+    bg: 'background',
+    kind: 'nonText',
+    why: 'focus ring on the canvas (SC 1.4.11)'
+  },
+  {
+    fg: 'ring',
+    bg: 'card',
+    kind: 'nonText',
+    why: 'focus ring inside Card (SC 1.4.11)'
+  },
+  {
+    fg: 'ring',
+    bg: 'sidebar',
+    kind: 'nonText',
+    why: 'focus ring in the sidebar (SC 1.4.11)'
+  },
+
+  {
+    fg: 'input',
+    bg: 'background',
+    kind: 'nonText',
+    why: 'Input / Textarea / Select boundary on the canvas (SC 1.4.11)'
+  },
+  {
+    fg: 'input',
+    bg: 'card',
+    kind: 'nonText',
+    why: 'field boundary inside Card (SC 1.4.11)'
+  },
+  {
+    fg: 'input',
+    bg: 'sidebar',
+    kind: 'nonText',
+    why: 'sidebar search field boundary (SC 1.4.11)'
+  },
+  {
+    fg: 'input',
+    bg: 'muted',
+    kind: 'nonText',
+    why: 'read-only field painted border-input over bg-muted (SC 1.4.11)'
+  }
+]
+
+/**
+ * Boundaries deliberately held BELOW the SC 1.4.11 floor, and why.
+ *
+ * SC 1.4.11 covers visual information required to identify user interface
+ * components and their state. A text field's boundary qualifies: without it a
+ * user cannot see where to click, so `--input` is gated at 3:1 above. A card
+ * edge, a section divider and a table rule do not — they group content that is
+ * already identifiable by the content itself, and shadcn paints `border-border`
+ * through a global `*` reset, so raising it to 3:1 would put a mid-grey stroke
+ * on every element in the product. That trades a deliberately light, airy
+ * identity for a compliance number the criterion never asked for.
+ *
+ * These pairs are still measured, against a visibility floor rather than a WCAG
+ * one: a decorative rule that cannot be seen at all is a bug of a different
+ * kind. The completeness check below then guarantees no boundary token can be
+ * quietly moved from the gated list into this one, which is the failure mode a
+ * documented exception invites.
+ */
+const DECORATIVE: readonly Pair[] = [
+  {
+    fg: 'border',
+    bg: 'background',
+    kind: 'nonText',
+    why: 'Card edge and Separator on the canvas'
+  },
+  {
+    fg: 'border',
+    bg: 'card',
+    kind: 'nonText',
+    why: 'boundary between nested surfaces'
+  },
+  {
+    fg: 'sidebar-border',
+    bg: 'sidebar',
+    kind: 'nonText',
+    why: 'sidebar separator'
+  }
+]
+
+/**
+ * A 1px rule below this ratio is invisible rather than subtle. It is a
+ * legibility floor of this palette's own choosing, not a WCAG criterion.
+ */
+const DECORATIVE_VISIBILITY_FLOOR = 1.15
+
+/**
+ * Tokens that no pair measures, each with the reason it cannot be measured
+ * here. The completeness test below requires every token to be in PAIRS,
+ * DECORATIVE or this list, so a new token cannot enter the palette unmeasured
+ * and unargued.
+ */
+const UNPAIRED: Readonly<Record<string, string>> = {
+  'shadcn-100':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner',
+  'shadcn-200':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner',
+  'shadcn-300':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner',
+  'shadcn-400':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner',
+  'shadcn-500':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner',
+  'shadcn-600':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner',
+  'shadcn-700':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner',
+  'shadcn-800':
+    'neutral ramp step; composed ad hoc by consumers, no fixed partner'
+}
+
+const sheet = readTokenSheet()
+
+/**
+ * Jest's `expect` takes no message argument, and a bare
+ * `expect(1.25).toBeGreaterThanOrEqual(3)` tells a reviewer nothing about which
+ * pair broke or what to do about it. Assertions below therefore compare an
+ * explanation against null: on failure Jest prints the whole explanation as the
+ * received value.
+ */
+function explainIf(failed: boolean, detail: string): string | null {
+  return failed ? detail : null
+}
+
+describe('contrast instrument', () => {
+  it('reproduces the WCAG reference extremes', () => {
+    const black = [0, 0, 0] as const
+    const white = [255, 255, 255] as const
+    expect(contrastRatio(black, white)).toBeCloseTo(21, 5)
+    expect(contrastRatio(white, white)).toBeCloseTo(1, 5)
+    expect(contrastRatio(black, black)).toBeCloseTo(1, 5)
+  })
+
+  it('is order-independent', () => {
+    const a = hslToRgb(0, 0, 44)
+    const b = hslToRgb(0, 0, 100)
+    expect(contrastRatio(a, b)).toBeCloseTo(contrastRatio(b, a), 10)
+  })
+
+  it('converts hsl() to the 8-bit triple a browser paints', () => {
+    expect(hslToRgb(0, 0, 100)).toEqual([255, 255, 255])
+    expect(hslToRgb(0, 0, 0)).toEqual([0, 0, 0])
+    expect(hslToRgb(0, 0, 44)).toEqual([112, 112, 112])
+    expect(hslToRgb(147, 75, 30)).toEqual([19, 134, 71])
+    expect(hslToRgb(37, 95, 49)).toEqual([244, 153, 6])
+  })
+
+  it('converts hex to the same triple', () => {
+    expect(hexToRgb('#f4f4f5')).toEqual([244, 244, 245])
+    expect(hexToRgb('#fff')).toEqual([255, 255, 255])
+  })
+
+  /**
+   * Pairs whose ratios were computed independently while choosing the palette.
+   * If the arithmetic here ever drifts, these break before any palette
+   * assertion does — a gate whose ruler is wrong is worse than no gate.
+   */
+  it.each([
+    ['light', 'foreground', 'background', 19.8],
+    ['light', 'muted-foreground', 'background', 4.95],
+    ['light', 'primary-foreground', 'primary', 17.18],
+    ['light', 'warning-foreground', 'warning', 9.41],
+    ['dark', 'foreground', 'background', 18.97],
+    ['dark', 'muted-foreground', 'background', 7.85],
+    ['dark', 'primary-foreground', 'primary', 17.18]
+  ] as const)(
+    'agrees with the %s %s / %s ratio computed off-line',
+    (theme, fg, bg, expected) => {
+      expect(tokenContrast(sheet, theme, fg, bg)).toBeCloseTo(expected, 2)
+    }
+  )
+
+  it('reads the hex ramp steps the palette declares alongside the hsl() tokens', () => {
+    expect(resolveToken(sheet, 'light', 'shadcn-100')).toEqual([244, 244, 245])
+    expect(resolveToken(sheet, 'dark', 'shadcn-800')).toEqual([250, 250, 250])
+  })
+
+  it('refuses a colour space it cannot measure instead of skipping the pair', () => {
+    const oklch = parseTokenSheet(
+      ':root { --foreground: oklch(0.2 0 0); } .dark { --foreground: hsl(0 0% 98%); }'
+    )
+    expect(() => resolveToken(oklch, 'light', 'foreground')).toThrow(
+      /expected an hsl\(\) literal/
+    )
+  })
+
+  it('refuses a token that is not declared instead of skipping the pair', () => {
+    const partial = parseTokenSheet(
+      ':root { --foreground: hsl(0 0% 4%); } .dark { --background: hsl(0 0% 4%); }'
+    )
+    expect(() => resolveToken(partial, 'dark', 'foreground')).toThrow(
+      /not declared in the dark palette/
+    )
+  })
+
+  it('refuses a stylesheet that declares a theme twice', () => {
+    expect(() =>
+      parseTokenSheet(
+        ':root { --a: hsl(0 0% 0%); } .dark { --a: hsl(0 0% 0%); } :root { --a: hsl(0 0% 100%); }'
+      )
+    ).toThrow(/exactly one `:root` block/)
+  })
+})
+
+describe('palette shape', () => {
+  it.each(THEMES)(
+    '%s declares exactly the tokens index.ts publishes',
+    (theme: Theme) => {
+      const declared = Object.keys(sheet[theme])
+        .map((name) => name.replace(/^--/, ''))
+        .sort()
+      expect(declared).toEqual([...TOKEN_NAMES].sort())
+    }
+  )
+
+  it('declares every token in both themes', () => {
+    const light = Object.keys(sheet.light).sort()
+    const dark = Object.keys(sheet.dark).sort()
+    expect(
+      explainIf(
+        JSON.stringify(dark) !== JSON.stringify(light),
+        `a token declared in one theme only silently falls back in the other. ` +
+          `light: [${light.join(', ')}] dark: [${dark.join(', ')}]`
+      )
+    ).toBeNull()
+  })
+
+  it('measures or explicitly excuses every token', () => {
+    const measured = new Set(
+      [...PAIRS, ...DECORATIVE].flatMap((pair) => [pair.fg, pair.bg])
+    )
+    const unmeasured = TOKEN_NAMES.filter(
+      (token) => !measured.has(token) && UNPAIRED[token] === undefined
+    )
+    expect(
+      explainIf(
+        unmeasured.length > 0,
+        `every token must appear in a measured pair or carry a written reason in UNPAIRED — ` +
+          `an unlisted token is a hole in the gate, not a passing token. Unlisted: ` +
+          `[${unmeasured.join(', ')}]`
+      )
+    ).toBeNull()
+  })
+
+  it('excuses no token that a pair already measures', () => {
+    const measured = new Set(
+      [...PAIRS, ...DECORATIVE].flatMap((pair) => [pair.fg, pair.bg])
+    )
+    const stale = Object.keys(UNPAIRED).filter((token) => measured.has(token))
+    expect(
+      explainIf(
+        stale.length > 0,
+        `delete these from UNPAIRED — they are measured, so the excuse is dead: ` +
+          `[${stale.join(', ')}]`
+      )
+    ).toBeNull()
+  })
+
+  it('keeps the gated and decorative boundary lists disjoint', () => {
+    const gated = new Set(PAIRS.map((pair) => `${pair.fg}|${pair.bg}`))
+    const overlap = DECORATIVE.filter((pair) =>
+      gated.has(`${pair.fg}|${pair.bg}`)
+    )
+    expect(
+      explainIf(
+        overlap.length > 0,
+        `a pair cannot be both held to SC 1.4.11 and excused from it: ` +
+          `[${overlap.map((pair) => `${pair.fg} on ${pair.bg}`).join(', ')}]`
+      )
+    ).toBeNull()
+  })
+})
+
+describe.each(THEMES)('%s palette contrast', (theme: Theme) => {
+  it.each(PAIRS.map((pair) => [`${pair.fg} on ${pair.bg}`, pair] as const))(
+    '%s clears its WCAG floor',
+    (label, pair) => {
+      const floor = THRESHOLDS[pair.kind]
+      const ratio = tokenContrast(sheet, theme, pair.fg, pair.bg)
+      expect(
+        explainIf(
+          ratio < floor,
+          `${label} (${theme}) — ${pair.why}. WCAG requires ${floor}:1, measured ` +
+            `${ratio.toFixed(2)}:1. Adjust the token in src/palette.css; do not relax the ` +
+            `threshold and do not add an exemption list.`
+        )
+      ).toBeNull()
+    }
+  )
+})
+
+describe.each(THEMES)('%s decorative boundaries', (theme: Theme) => {
+  it.each(
+    DECORATIVE.map((pair) => [`${pair.fg} on ${pair.bg}`, pair] as const)
+  )('%s stays visible', (label, pair) => {
+    const ratio = tokenContrast(sheet, theme, pair.fg, pair.bg)
+    expect(
+      explainIf(
+        ratio < DECORATIVE_VISIBILITY_FLOOR,
+        `${label} (${theme}) — ${pair.why}. Held to a ${DECORATIVE_VISIBILITY_FLOOR}:1 ` +
+          `visibility floor rather than SC 1.4.11's 3:1, because it identifies no component; ` +
+          `measured ${ratio.toFixed(2)}:1, which is invisible.`
+      )
+    ).toBeNull()
+  })
+})

--- a/packages/sindarian-tokens/src/tokens.css
+++ b/packages/sindarian-tokens/src/tokens.css
@@ -1,0 +1,76 @@
+/*
+ * @lerianstudio/sindarian-tokens — the Lerian internal-console identity.
+ *
+ * This is the entry a Tailwind v4 console imports. It brings the palette
+ * (palette.css), the theme-invariant radius, the `dark` variant, and the
+ * `@theme inline` mapping that turns the tokens into Tailwind utilities
+ * (`bg-background`, `text-muted-foreground`, `border-input`, `rounded-lg`).
+ *
+ * Import it AFTER `tailwindcss` and after any component library that ships its
+ * own `@theme`, so this mapping wins:
+ *
+ *   @import 'tailwindcss';
+ *   @import '@lerianstudio/sindarian-ui/…';     (optional)
+ *   @import '@lerianstudio/sindarian-tokens/tokens.css';
+ *
+ * A consumer that owns its own `@theme` mapping and wants only the colour
+ * variables can import '@lerianstudio/sindarian-tokens/palette.css' instead;
+ * that file needs no Tailwind.
+ *
+ * `@theme inline` (not plain `@theme`) is required: it inlines `var(--x)` at
+ * the use site instead of snapshotting the value, which is what lets the
+ * `.dark` block re-point every utility at runtime.
+ */
+
+@import './palette.css';
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --radius: 0.5rem;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-shadcn-100: var(--shadcn-100);
+  --color-shadcn-200: var(--shadcn-200);
+  --color-shadcn-300: var(--shadcn-300);
+  --color-shadcn-400: var(--shadcn-400);
+  --color-shadcn-500: var(--shadcn-500);
+  --color-shadcn-600: var(--shadcn-600);
+  --color-shadcn-700: var(--shadcn-700);
+  --color-shadcn-800: var(--shadcn-800);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}

--- a/packages/sindarian-tokens/tsconfig.eslint.json
+++ b/packages/sindarian-tokens/tsconfig.eslint.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../utils/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["jest", "node"],
+    "noEmit": true,
+    "allowJs": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/sindarian-tokens/tsconfig.json
+++ b/packages/sindarian-tokens/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../utils/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["jest"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/__tests__", "**/*.spec.ts", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Why

Lerian's internal consoles are meant to look like one product. Today the identity lives as ~40 CSS custom properties inside **one app file** — `backoffice-console/apps/backoffice/src/app/globals.css` — and `caradhras/ui/src/styles.css` carries a hand-made **copy** of the same values.

Two copies, no contract. The first palette tweak on either side diverges silently, and until this week nothing measured either one.

> `packages/sindarian-ui/src/globals.css` is a *different*, Lerian-yellow identity that backoffice deliberately does not import. It is untouched here.

## What this adds

`packages/sindarian-tokens` → `@lerianstudio/sindarian-tokens`, the single source both consoles import.

- **`tokens.css`** — palette, `--radius`, the dark custom variant and the `@theme inline` mapping, for Tailwind v4 CSS-first consumers.
- **`palette.css`** — for a consumer that owns its own theme mapping.

Values are full `hsl()` literals rather than the bare triplets backoffice re-wraps at every use site, so a token works in `color-mix()` and in plain CSS with no implicit wrapper contract.

Registered in the changed-paths lists of **`ci.yml` and `release.yml`** (filter-paths, the `workflow_dispatch` choice, and the changelog filter). A package missing from those lists is never linted, tested or published — the silent no-op this would otherwise have been.

## Eight values deviate from the backoffice originals, to clear a WCAG 2.2 AA floor

Each is annotated inline with its before/after ratio.

| theme | token | before | after | ratio |
|---|---|---|---|---|
| light | `--destructive` | `0 84% 60%` | `0 84% 48%` | 3.62 → **4.67** |
| light | `--success` | `147 75% 34%` | `147 75% 30%` | 3.72 → **4.64** |
| light | `--info` | `217 91% 60%` | `217 91% 53%` | 3.64 → **4.58** |
| light | `--muted-foreground` | `0 0% 45%` | `0 0% 44%` | 4.35 → **4.54** |
| light | `--input` | `0 0% 90%` | `0 0% 55%` | 1.25 → **3.36** |
| dark | `--success-foreground` | `0 0% 100%` | `0 0% 0%` | 2.30 → **9.12** |
| dark | `--info-foreground` | `0 0% 100%` | `0 0% 0%` | 2.52 → **8.34** |
| dark | `--input` | `0 0% 15%` | `0 0% 44%` | 1.31 → **4.00** |

**The dark status fills keep their vivid greens and blues and flip the ink to black** — as `--warning-foreground` already did on the equally light amber. Darkening those fills to carry white ink would have put a dark badge on a near-black canvas.

**`--border` and `--sidebar-border` are deliberately left below 3:1.** SC 1.4.11 covers visual information required to identify a component or its state: a *field boundary* qualifies, a card edge or table rule does not. Raising every boundary would turn a deliberately light, airy identity into a heavy-bordered one — a design regression traded for a compliance number. shadcn also paints `border-border` through a global reset, so the change would land far beyond the components the criterion is about.

The visible consequence of the `--input` change is that a form field's boundary goes from effectively invisible to clearly delimited, without becoming heavy — checked by rendering both values side by side in both themes.

## Tests

`tokens.contrast.test.ts` re-measures every pair in both themes on every run, **with no exemption list**. That is the point: the `caradhras` gate it replaces carries a `KNOWN_SHORTFALLS` ratchet that froze fourteen pairs precisely because the palette lived in someone else's app. Owning the palette here removes the reason for the ratchet.

Proven by mutation, not by inspection — reported in the commit.

## Gates

`npm run lint`, `test` (**75 tests**), `build` — all exit 0.

## Not in this PR

Wiring the consumers. `backoffice-console` deleting its app-level token block, and `caradhras` deleting its copy, are one PR per repo **after this package publishes** — pinning a dependency that does not exist yet is how a green PR merges into a broken install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
